### PR TITLE
Disable goreleaser scm publish

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: kubernetes-operator
 
+release:
+  disable: true
+
 builds:
   - id: manager
     dir: cmd


### PR DESCRIPTION
Disables unused scm release from goreleaser as we don't need to publish binaries