### PR TITLE
Fix conditional RBAC to be added on NetBird key existence

### DIFF
--- a/helm/kubernetes-operator/Chart.yaml
+++ b/helm/kubernetes-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: kubernetes-operator
 description: NetBird Kubernetes Operator
 type: application
-version: 0.1.6
+version: 0.1.7
 appVersion: "0.1.2"

--- a/helm/kubernetes-operator/templates/rbac.yaml
+++ b/helm/kubernetes-operator/templates/rbac.yaml
@@ -27,7 +27,7 @@ rules:
   - get
   - patch
   - update
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret }}
 - apiGroups:
   - netbird.io
   resources:
@@ -108,7 +108,7 @@ rules:
   - get
   - list
   - watch
-{{- if or .Values.ingress.enabled .Values.clusterSecretsPermissions.allowAllSecrets }}
+{{- if or (or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret) .Values.clusterSecretsPermissions.allowAllSecrets }}
 - apiGroups:
   - ""
   resources:
@@ -117,7 +117,7 @@ rules:
   - get
   - list
   - watch
-{{- if .Values.ingress.enabled }}
+{{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret }}
   - patch
   - update
   - create


### PR DESCRIPTION
Operator checks for existence of NetBird API key to create controllers for Service, NBResource, NBPolicy ...etc, while the Helm chart checks for Values.ingress.enabled, this causes crashes if NetBird API Key is provided but ingress.enabled is set to `false`.

This fixes this discrepancy by checking NetBird API key in Helm instead of ingress enabled value.

resolves #13 