### PR TITLE
Fix Job field name

### DIFF
--- a/helm/kubernetes-operator/templates/pre-delete.yaml
+++ b/helm/kubernetes-operator/templates/pre-delete.yaml
@@ -9,7 +9,7 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  backOffLimit: 3
+  backoffLimit: 3
   template:
     metadata:
       name: {{ include "kubernetes-operator.fullname" . }}
@@ -44,7 +44,7 @@ metadata:
     helm.sh/hook: pre-delete
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
-  backOffLimit: 3
+  backoffLimit: 3
   template:
     metadata:
       name: {{ include "kubernetes-operator.fullname" . }}


### PR DESCRIPTION
The proper name of the field is `backoffLimit` - with small `o`, not `backOffLimit`: https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/job-v1/#lifecycle

Maybe some systems do some normalization to make both working, but in my case with k8s v1.31 on EKS it fails with `unknown field "spec.backOffLimit"`