### PR TITLE
use env entries instead of envFrom

### DIFF
--- a/helm/kubernetes-operator/templates/deployment.yaml
+++ b/helm/kubernetes-operator/templates/deployment.yaml
@@ -78,13 +78,16 @@ spec:
             successThreshold: {{ .Values.operator.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.operator.livenessProbe.timeoutSeconds }}
           {{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret }}
-          envFrom:
-            - secretRef:
-                {{- if .Values.netbirdAPI.keyFromSecret }}
-                name: {{.Values.netbirdAPI.keyFromSecret}}
-                {{- else }}
-                name: {{ include "kubernetes-operator.fullname" . }}
-                {{- end }}
+          env:
+            - name: NB_API_KEY
+                valueFrom:
+                  {{- if .Values.netbirdAPI.keyFromSecret }}
+                  name: {{.Values.netbirdAPI.keyFromSecretName}}
+                  key: {{.Values.netbirdAPI.keyFromSecretKey}}
+                  {{- else }}
+                  name: {{ include "kubernetes-operator.fullname" . }}
+                  key: NB_API_KEY
+                  {{- end }}
           {{- end }}
           readinessProbe:
             failureThreshold: 3

--- a/helm/kubernetes-operator/values.yaml
+++ b/helm/kubernetes-operator/values.yaml
@@ -17,8 +17,7 @@ webhook:
   enableCertManager: true
 
   # Narrow down validation and mutation webhooks namespaces
-  namespaceSelectors:
-    []
+  namespaceSelectors: []
     # - key: foo
     #   operator: In
     #   values:
@@ -26,8 +25,7 @@ webhook:
 
   # Narrow down validation and mutation webhooks objects
   objectSelector:
-    matchExpressions:
-      []
+    matchExpressions: []
       # - key: app.kubernetes.io/name
       #   operator: NotIn
       #   values:
@@ -82,12 +80,13 @@ operator:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-        - ALL
+      - ALL
 
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+
 
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
@@ -96,8 +95,7 @@ operator:
     # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 9443
 
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -162,24 +160,22 @@ ingress:
     # nodeSelector: {}
     # tolerations: []
     # Only needed if namespacedNetworks is set to true
-    namespaces:
-      {}
+    namespaces: {}
       # default:
-      # replicas: 3
-      # resources:
-      #   requests:
-      #     cpu: 100m
-      #     memory: 100Mi
-      #   limits:
-      #     cpu: 100m
-      #     memory: 100Mi
-      # labels: {}
-      # annotations: {}
-      # nodeSelector: {}
-      # tolerations: []
+        # replicas: 3
+        # resources:
+        #   requests:
+        #     cpu: 100m
+        #     memory: 100Mi
+        #   limits:
+        #     cpu: 100m
+        #     memory: 100Mi
+        # labels: {}
+        # annotations: {}
+        # nodeSelector: {}
+        # tolerations: []
   # NetBird Policies for use with exposed services
-  policies:
-    {}
+  policies: {}
     # default:
     #   name: Kubernetes Default Policy
     #   sourceGroups:
@@ -191,8 +187,7 @@ cluster:
   # Cluster name (used for generating network and network resource names in NetBird)
   name: kubernetes
 
-netbirdAPI:
-  {}
+netbirdAPI: {}
   # NetBird Service Account Token
   # key: "nbp_m0LM9ZZvDUzFO0pY50iChDOTxJgKFM3DIqmZ"
   # keyFromSecretName: "Secret name"

--- a/helm/kubernetes-operator/values.yaml
+++ b/helm/kubernetes-operator/values.yaml
@@ -17,7 +17,8 @@ webhook:
   enableCertManager: true
 
   # Narrow down validation and mutation webhooks namespaces
-  namespaceSelectors: []
+  namespaceSelectors:
+    []
     # - key: foo
     #   operator: In
     #   values:
@@ -25,7 +26,8 @@ webhook:
 
   # Narrow down validation and mutation webhooks objects
   objectSelector:
-    matchExpressions: []
+    matchExpressions:
+      []
       # - key: app.kubernetes.io/name
       #   operator: NotIn
       #   values:
@@ -70,7 +72,7 @@ operator:
     name: ""
 
   # This is for setting Kubernetes Annotations to a Pod.
-  # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/ 
+  # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   podAnnotations: {}
   # This is for setting Kubernetes Labels to a Pod.
   # For more information checkout: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -80,13 +82,12 @@ operator:
     allowPrivilegeEscalation: false
     capabilities:
       drop:
-      - ALL
+        - ALL
 
   podSecurityContext:
     runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
-
 
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
@@ -95,7 +96,8 @@ operator:
     # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
     port: 9443
 
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 100m
     #   memory: 128Mi
@@ -160,22 +162,24 @@ ingress:
     # nodeSelector: {}
     # tolerations: []
     # Only needed if namespacedNetworks is set to true
-    namespaces: {}
+    namespaces:
+      {}
       # default:
-        # replicas: 3
-        # resources:
-        #   requests:
-        #     cpu: 100m
-        #     memory: 100Mi
-        #   limits:
-        #     cpu: 100m
-        #     memory: 100Mi
-        # labels: {}
-        # annotations: {}
-        # nodeSelector: {}
-        # tolerations: []
+      # replicas: 3
+      # resources:
+      #   requests:
+      #     cpu: 100m
+      #     memory: 100Mi
+      #   limits:
+      #     cpu: 100m
+      #     memory: 100Mi
+      # labels: {}
+      # annotations: {}
+      # nodeSelector: {}
+      # tolerations: []
   # NetBird Policies for use with exposed services
-  policies: {}
+  policies:
+    {}
     # default:
     #   name: Kubernetes Default Policy
     #   sourceGroups:
@@ -187,7 +191,9 @@ cluster:
   # Cluster name (used for generating network and network resource names in NetBird)
   name: kubernetes
 
-netbirdAPI: {}
+netbirdAPI:
+  {}
   # NetBird Service Account Token
   # key: "nbp_m0LM9ZZvDUzFO0pY50iChDOTxJgKFM3DIqmZ"
-  # keyFromSecret: "Secret name with NB_API_KEY=Service Account Token"
+  # keyFromSecretName: "Secret name"
+  # keyFromSecretKey: "NB_API_KEY"


### PR DESCRIPTION
The reason for this PR is that currently if the secret doesn’t have the key NB_API_KEY yet at deployment time, the deployment will still run and pull in an env list that doesn’t include NB_API_KEY since the envFrom will just pull any and all keys it finds in the secret and makes env vars out of them.  then at a later point, once the NB_API_KEY key is populated in the secret, one has to bounce the pod to get the key to be picked up.

if you use the env: valueFrom syntax using a named key, if that named key doesn’t exist, the deployment should give an error and retry until the secret key is available