### PR TITLE
feat: implement option for defining clientImage

### DIFF
--- a/helm/kubernetes-operator/templates/deployment.yaml
+++ b/helm/kubernetes-operator/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
           {{- if .Values.managementURL }}
           - --netbird-management-url={{.Values.managementURL}}
           {{- end }}
+          {{- if .Values.clientImage }}
+          - --netbird-client-image={{.Values.clientImage}}
+          {{- end }}
           {{- if .Values.cluster.name }}
           - --cluster-name={{.Values.cluster.name}}
           {{- end }}


### PR DESCRIPTION
This allows you to set the netbird images for the routers (`NBRoutingPeer`) with the newly introduced `clientImage` value.