### PR TITLE
Add logging level to NetBird Helm Deployment

### DIFF
--- a/helm/kubernetes-operator/templates/deployment.yaml
+++ b/helm/kubernetes-operator/templates/deployment.yaml
@@ -87,8 +87,9 @@ spec:
             periodSeconds: {{ .Values.operator.livenessProbe.periodSeconds }}
             successThreshold: {{ .Values.operator.livenessProbe.successThreshold }}
             timeoutSeconds: {{ .Values.operator.livenessProbe.timeoutSeconds }}
-          {{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret }}
+          {{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret .Values.operator.logLevel }}
           env:
+            {{- if or .Values.netbirdAPI.key .Values.netbirdAPI.keyFromSecret }}
             - name: NB_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -99,6 +100,11 @@ spec:
                   name: {{ include "kubernetes-operator.fullname" . }}
                   key: NB_API_KEY
                   {{- end }}
+            {{- end }}
+            {{- if .Values.operator.logLevel }}
+            - name: NB_LOG_LEVEL
+              value: {{ .Values.operator.logLevel | quote }}
+            {{- end }}
           {{- end }}
           readinessProbe:
             failureThreshold: 3

--- a/helm/kubernetes-operator/values.yaml
+++ b/helm/kubernetes-operator/values.yaml
@@ -90,7 +90,6 @@ operator:
     seccompProfile:
       type: RuntimeDefault
 
-
   # This is for setting up a service more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/
   service:
     # This sets the service type more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
@@ -120,6 +119,9 @@ operator:
     periodSeconds: 10
     successThreshold: 1
     timeoutSeconds: 1
+
+  # Log level for NetBird operator (e.g., debug, info, warn, error)
+  logLevel: ""
 
   # Additional volumes on the output Deployment definition.
   volumes: []


### PR DESCRIPTION
There was a need to see the debugging logs from NetBird, so I've added the NB_LOG_LEVEL environment variable to the k8s deployment in the helm chart.