### PR TITLE
feat: add router namePrefix

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -76,6 +76,7 @@ func main() {
 		netbirdAPIKey                string
 		allowAutomaticPolicyCreation bool
 		defaultLabels                string
+		routingPeerNamePrefix        string
 	)
 	flag.StringVar(&managementURL, "netbird-management-url", "https://api.netbird.io", "Management service URL")
 	flag.StringVar(&clientImage, "netbird-client-image", "netbirdio/netbird:latest", "Image for netbird client container")
@@ -104,6 +105,12 @@ func main() {
 		"default-labels",
 		"",
 		"Default labels used for all resources, in format key=value,key=value",
+	)
+	flag.StringVar(
+		&routingPeerNamePrefix,
+		"routing-peer-name-prefix",
+		"",
+		"Prefix applied to routing peer names (final name becomes <prefix>router)",
 	)
 
 	// Controller generic flags
@@ -255,6 +262,7 @@ func main() {
 			NamespacedNetworks:  namespacedNetworks,
 			ControllerNamespace: controllerNamespace,
 			DefaultLabels:       defaultLabelsMap,
+			RouterNamePrefix:    routingPeerNamePrefix,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "unable to create controller", "controller", "Service")
 			os.Exit(1)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,8 +62,9 @@ With this setup, all peers with the same extra label would be used in a DNS roun
     1. Alternatively, provision secret in the same namespace as the operator and set the key `NB_API_KEY` to the access token generated.
     2. Set `netbirdAPI.keyFromSecret` to the name of the secret created.
 4. Set `ingress.enabled` to `true`.
-    1. Optionally, to provision the network immediately, set `ingress.router.enabled` to `true`.
-    2. Optionally, to provision 1 network per namespace, set `ingress.namespacedNetworks` to `true`.
+  1. Optionally, to provision the network immediately, set `ingress.router.enabled` to `true`.
+  2. Optionally, to provision 1 network per namespace, set `ingress.namespacedNetworks` to `true`.
+  3. Optionally, set `ingress.router.namePrefix` to prepend a custom string to every routing peer name (resulting name becomes `<prefix>-router`).
 5. Run `helm install` or `helm upgrade`.
 
 Minimum values.yaml example:

--- a/examples/ingress/values.yaml
+++ b/examples/ingress/values.yaml
@@ -5,6 +5,7 @@ ingress:
   enabled: true
   router:
     enabled: true
+    # namePrefix: "demo-"
 #  policies:
 #    default:
 #      name: Kubernetes Default Policy

--- a/helm/kubernetes-operator/templates/deployment.yaml
+++ b/helm/kubernetes-operator/templates/deployment.yaml
@@ -54,6 +54,9 @@ spec:
           {{- if .Values.ingress.namespacedNetworks }}
           - --namespaced-networks={{.Values.ingress.namespacedNetworks}}
           {{- end }}
+          {{- if .Values.ingress.router.namePrefix }}
+          - --routing-peer-name-prefix={{ .Values.ingress.router.namePrefix }}
+          {{- end }}
           {{- if .Values.cluster.dns }}
           - --cluster-dns={{.Values.cluster.dns}}
           {{- end }}

--- a/helm/kubernetes-operator/templates/kubernetes-nbresource.yaml
+++ b/helm/kubernetes-operator/templates/kubernetes-nbresource.yaml
@@ -3,6 +3,10 @@
 {{- if .Values.ingress.namespacedNetworks }}
 {{- $routerNS = "default" }}
 {{- end }}
+{{- $routerName := "router" }}
+{{- if .Values.ingress.router.namePrefix }}
+{{- $routerName = printf "%s-router" .Values.ingress.router.namePrefix }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -32,7 +36,7 @@ spec:
         - bash
         - -c
         args:
-        - kubectl wait --for 'jsonpath={.status.networkID}' -n {{ $routerNS }} nbroutingpeer router; 
+        - kubectl wait --for 'jsonpath={.status.networkID}' -n {{ $routerNS }} nbroutingpeer {{ $routerName }}; 
       containers:
       - name: apply-nbresource
         image: "bitnami/kubectl:latest"
@@ -47,10 +51,14 @@ spec:
               name: kubernetes
               namespace: default
             spec:
+              {{- if .Values.cluster.apiserver }}
+              address: {{ .Values.cluster.apiserver }}
+              {{- else }}
               address: kubernetes.default.{{.Values.cluster.dns}}
+              {{- end }}
               groups:
               {{- if .Values.ingress.kubernetesAPI.groups }}
-              {{ toYaml .Values.ingress.kubernetesAPI.groups }}
+              {{ toYaml .Values.ingress.kubernetesAPI.groups | nindent 14 }}
               {{- else }}
               - {{ .Values.cluster.name }}-default-api-access
               {{- end }}
@@ -65,7 +73,7 @@ spec:
         - bash
         - -c
         args:
-        - kubectl delete NBResource --ignore-not-found -n default kubernetes; export NETWORK_ID=$(kubectl get NBRoutingPeer -n {{ $routerNS }} router -o 'jsonpath={.status.networkID}'); echo "$NBRESOURCE_VALUE" | envsubst | kubectl apply -f -
+        - kubectl delete NBResource --ignore-not-found -n default kubernetes; export NETWORK_ID=$(kubectl get NBRoutingPeer -n {{ $routerNS }} {{ $routerName }} -o 'jsonpath={.status.networkID}'); echo "$NBRESOURCE_VALUE" | envsubst | kubectl apply -f -
       serviceAccountName: {{ include "kubernetes-operator.serviceAccountName" . }}
       restartPolicy: Never
 {{- end }}

--- a/helm/kubernetes-operator/templates/nbroutingpeers.yaml
+++ b/helm/kubernetes-operator/templates/nbroutingpeers.yaml
@@ -1,4 +1,6 @@
 {{- if and .Values.ingress.enabled .Values.ingress.router.enabled }}
+{{- $routerNamePrefix := default "" .Values.ingress.router.namePrefix }}
+{{- $routerResourceName := printf "%s%s" $routerNamePrefix "router" }}
 {{- if .Values.ingress.namespacedNetworks }}
 {{ $defaults := .Values.ingress.router }}
 {{ range $k, $v := .Values.ingress.router.namespaces }}
@@ -10,9 +12,9 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     {{- include "kubernetes-operator.labels" $ | nindent 4 }}
-  name: router
+  name: {{ $routerResourceName }}
   namespace: {{ $k }}
-{{ $spec := merge $defaults $v }}
+{{ $spec := merge (dict) $defaults $v }}
 {{- if or (or (or $spec.replicas $spec.resources) (or $spec.labels $spec.annotations)) (or $spec.nodeSelector $spec.tolerations) }}
 spec:
   {{- if $spec.replicas }}
@@ -51,7 +53,7 @@ metadata:
   labels:
     app.kubernetes.io/component: operator
     {{- include "kubernetes-operator.labels" $ | nindent 4 }}
-  name: router
+  name: {{ $routerResourceName }}
 {{- if or (or (or .replicas .resources) (or .labels .annotations)) (or .nodeSelector .tolerations) }}
 spec:
   {{- if .replicas }}

--- a/helm/kubernetes-operator/templates/nbroutingpeers.yaml
+++ b/helm/kubernetes-operator/templates/nbroutingpeers.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.ingress.enabled .Values.ingress.router.enabled }}
 {{- $routerNamePrefix := default "" .Values.ingress.router.namePrefix }}
-{{- $routerResourceName := printf "%s%s" $routerNamePrefix "router" }}
+{{- $routerResourceName := printf "%s-%s" $routerNamePrefix "router" }}
 {{- if .Values.ingress.namespacedNetworks }}
 {{ $defaults := .Values.ingress.router }}
 {{ range $k, $v := .Values.ingress.router.namespaces }}

--- a/helm/kubernetes-operator/values.yaml
+++ b/helm/kubernetes-operator/values.yaml
@@ -150,6 +150,8 @@ ingress:
   router:
     # Deploy routing peer(s)
     enabled: false
+    # Prefix appended to routing peer names (final name becomes <prefix>router)
+    namePrefix: ""
     # replicas: 3
     # resources:
     #   requests:
@@ -187,6 +189,8 @@ ingress:
 cluster:
   # Cluster DNS name (used for webhooks certificates and for network resource DNS names)
   dns: svc.cluster.local
+  # Cluster API server address (overrides in-cluster address detection)
+  # apiserver: https://my-custom-apiserver:6443
   # Cluster name (used for generating network and network resource names in NetBird)
   name: kubernetes
 


### PR DESCRIPTION
**Problem Statement**
Managing multiple Kubernetes clusters with a single NetBird account made it hard to differentiate routing peers: every cluster created a peer named **router**, so the NetBird dashboard couldn’t tell them apart besides from groups. In addition, Kubernetes API exposure relied on DNS-only addresses, which collide across clusters and break access when multiple policies target the same DNS entry.

**Key Updates**

- Added a configurable routing-peer name prefix (ingress.router.namePrefix → --routing-peer-name-prefix) and plumbed it through the Service controller so each cluster (or namespace, if namespaced networks are enabled) can build unique peer names such as <cluster>-router.

- Updated Helm values, deployment args, docs, and examples to surface the new option, plus added controller logging/tests around the behavior.

- Enhanced the Kubernetes API NBResource job to accept explicit IP addresses (cluster.apiserver) so networks can target unique endpoints per cluster instead of sharing the default DNS entry.

- Fixed template rendering issues (groups indentation) to ensure Helm hooks apply cleanly when custom group lists are provided.