### PR TITLE
feat: netbird load balancer class

### DIFF
--- a/helm/kubernetes-operator/templates/rbac.yaml
+++ b/helm/kubernetes-operator/templates/rbac.yaml
@@ -85,6 +85,7 @@ rules:
   - ""
   resources:
   - services/finalizers
+  - services/status
   verbs:
   - update
 - apiGroups:

--- a/internal/controller/nbroutingpeer_controller.go
+++ b/internal/controller/nbroutingpeer_controller.go
@@ -241,9 +241,6 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 		updatedDeployment.Spec.Template.Spec.NodeSelector = nbrp.Spec.NodeSelector
 		updatedDeployment.Spec.Template.ObjectMeta.Labels = podLabels
 		updatedDeployment.Spec.Template.Spec.Volumes = nbrp.Spec.Volumes
-		updatedDeployment.Spec.Template.ObjectMeta.Labels = map[string]string{
-			"app.kubernetes.io/name": "netbird-router",
-		}
 		if len(updatedDeployment.Spec.Template.Spec.Containers) != 1 {
 			updatedDeployment.Spec.Template.Spec.Containers = []corev1.Container{}
 		}

--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -19,6 +19,7 @@ package v1
 import (
 	"context"
 	"fmt"
+	"github.com/netbirdio/kubernetes-operator/internal/util"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -130,6 +131,9 @@ func (d *PodNetbirdInjector) Default(ctx context.Context, obj runtime.Object) er
 			Capabilities: &corev1.Capabilities{
 				Add: []corev1.Capability{"NET_ADMIN"},
 			},
+			RunAsUser:    util.Ptr[int64](0),
+			RunAsGroup:   util.Ptr[int64](0),
+			RunAsNonRoot: util.Ptr(false),
 		},
 		VolumeMounts: nbSetupKey.Spec.VolumeMounts,
 	})


### PR DESCRIPTION
- Added support for Services with type LoadBalancer.
  When `loadBalancerClass: netbird` is set, the operator now injects
  the proper LoadBalancer ingress into Service status.
```yaml
status:                                                                                                                         
  loadBalancer:                                                                                                                 
    ingress:                                                                                                                    
    - hostname: cilium-gateway-netbird-gateway.gateway-api-test.svc.cluster.local 
 ```
- Fixed applying labels to NBRoutingPeer pods.