### PR TITLE
Remove pod label overwriting

### DIFF
--- a/internal/controller/nbroutingpeer_controller.go
+++ b/internal/controller/nbroutingpeer_controller.go
@@ -241,9 +241,6 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 		updatedDeployment.Spec.Template.Spec.NodeSelector = nbrp.Spec.NodeSelector
 		updatedDeployment.Spec.Template.ObjectMeta.Labels = podLabels
 		updatedDeployment.Spec.Template.Spec.Volumes = nbrp.Spec.Volumes
-		updatedDeployment.Spec.Template.ObjectMeta.Labels = map[string]string{
-			"app.kubernetes.io/name": "netbird-router",
-		}
 		if len(updatedDeployment.Spec.Template.Spec.Containers) != 1 {
 			updatedDeployment.Spec.Template.Spec.Containers = []corev1.Container{}
 		}


### PR DESCRIPTION
Pod labels are being set in line 242, and the`podLabels` variable already contains the extra `"app.kubernetes.io/name": "netbird-router"` label, so lines 244-246 are effectively just overwriting any labels that have been set in the crd.

This is blocking us from using this crd because we need a label disabling istio injection for the peer to work correctly.