### PR TITLE
fix potential panic when acessing empty list

### DIFF
--- a/internal/controller/nbroutingpeer_controller.go
+++ b/internal/controller/nbroutingpeer_controller.go
@@ -245,7 +245,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 			"app.kubernetes.io/name": "netbird-router",
 		}
 		if len(updatedDeployment.Spec.Template.Spec.Containers) != 1 {
-			updatedDeployment.Spec.Template.Spec.Containers = []corev1.Container{}
+			updatedDeployment.Spec.Template.Spec.Containers = []corev1.Container{{}}
 		}
 		updatedDeployment.Spec.Template.Spec.Containers[0].Name = "netbird"
 		updatedDeployment.Spec.Template.Spec.Containers[0].Image = r.ClientImage


### PR DESCRIPTION
while fixing #87, noticed a couple lines down that if the containers spec has more than 1 container, the code probably intends to set Spec.Containers to a list with a single container, but is instead setting it to an empty list. The very next lines are trying to access the 1st element of this empty list, which will result in a panic