### PR TITLE
fix: rendering of protocols and ports in NBPolicy

### DIFF
--- a/helm/kubernetes-operator/templates/nbpolicies.yaml
+++ b/helm/kubernetes-operator/templates/nbpolicies.yaml
@@ -19,10 +19,12 @@ spec:
   description: {{ $v.description }}
   {{- end }}
   {{- if $v.protocols }}
-  protocols: {{ $v.protocols }}
+  protocols:
+  {{ toYaml $v.protocols | nindent 4}}
   {{- end }}
   {{- if $v.ports }}
-  ports: {{ $v.ports }}
+  ports:
+  {{ toYaml $v.ports | nindent 4}}
   {{- end }}
   {{- if hasKey $v "bidirectional" }}
   bidirectional: {{ $v.bidirectional }}


### PR DESCRIPTION
Minor adjustment to the NBPolicy template to make ports and protocols render as lists instead of strings. 

Previously a values file like

```yaml
policies:
  demo-policy:
    name: "Demo Policy"
    sourceGroups:
      - demogroup
      - demogroup2
    ports:
      - 443
      - 80
    protocols:
      - tcp
      - udp
```

would result in a rendered manifest like

```yaml
spec:
  bidirectional: false
  name: Demo Policy
  ports:
    - 80 443
  protocols:
    - tcp udp
  sourceGroups:
    - demogroup
    - demogroup2
```

(.spec.ports[0]: expected numeric (int or float), got string)