### PR TITLE
fix(nbpolicy): swap reversed strings.Contains arguments in handleDelete

### DIFF
--- a/internal/controller/nbpolicy_controller.go
+++ b/internal/controller/nbpolicy_controller.go
@@ -350,14 +350,14 @@ func (r *NBPolicyReconciler) syncPolicy(ctx context.Context, nbPolicy *netbirdio
 func (r *NBPolicyReconciler) handleDelete(ctx context.Context, nbPolicy *netbirdiov1.NBPolicy, logger logr.Logger) error {
 	if nbPolicy.Status.TCPPolicyID != nil {
 		err := r.netbird.Policies.Delete(ctx, *nbPolicy.Status.TCPPolicyID)
-		if err != nil && !strings.Contains("not found", err.Error()) {
+		if err != nil && !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		nbPolicy.Status.TCPPolicyID = nil
 	}
 	if nbPolicy.Status.UDPPolicyID != nil {
 		err := r.netbird.Policies.Delete(ctx, *nbPolicy.Status.UDPPolicyID)
-		if err != nil && !strings.Contains("not found", err.Error()) {
+		if err != nil && !strings.Contains(err.Error(), "not found") {
 			return err
 		}
 		nbPolicy.Status.UDPPolicyID = nil

--- a/internal/controller/nbpolicy_controller_test.go
+++ b/internal/controller/nbpolicy_controller_test.go
@@ -659,16 +659,20 @@ var _ = Describe("NBPolicy Controller", func() {
 
 				Expect(k8sClient.Delete(ctx, nbpolicy)).To(Succeed())
 
+				tcpDeleteAttempted := false
 				mux.HandleFunc("/api/policies/policyidtcp-gone", func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodDelete {
+						tcpDeleteAttempted = true
 						w.WriteHeader(http.StatusNotFound)
 						_, err := w.Write([]byte(`{"message":"policy: policyidtcp-gone not found","code":404}`))
 						Expect(err).NotTo(HaveOccurred())
 					}
 				})
 
+				udpDeleteAttempted := false
 				mux.HandleFunc("/api/policies/policyidudp-gone", func(w http.ResponseWriter, r *http.Request) {
 					if r.Method == http.MethodDelete {
+						udpDeleteAttempted = true
 						w.WriteHeader(http.StatusNotFound)
 						_, err := w.Write([]byte(`{"message":"policy: policyidudp-gone not found","code":404}`))
 						Expect(err).NotTo(HaveOccurred())
@@ -679,6 +683,8 @@ var _ = Describe("NBPolicy Controller", func() {
 					NamespacedName: typeNamespacedName,
 				})
 				Expect(err).NotTo(HaveOccurred())
+				Expect(tcpDeleteAttempted).To(BeTrue())
+				Expect(udpDeleteAttempted).To(BeTrue())
 
 				err = k8sClient.Get(ctx, typeNamespacedName, nbpolicy)
 				Expect(errors.IsNotFound(err)).To(BeTrue())

--- a/internal/controller/nbpolicy_controller_test.go
+++ b/internal/controller/nbpolicy_controller_test.go
@@ -643,5 +643,46 @@ var _ = Describe("NBPolicy Controller", func() {
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 		})
+
+		When("NBPolicy is set for deletion but policies are already gone from API", func() {
+			It("should remove finalizer and complete deletion", func() {
+				controllerReconciler := &NBPolicyReconciler{
+					Client:      k8sClient,
+					Scheme:      k8sClient.Scheme(),
+					netbird:     netbirdClient,
+					ClusterName: "Kubernetes",
+				}
+
+				nbpolicy.Status.TCPPolicyID = util.Ptr("policyidtcp-gone")
+				nbpolicy.Status.UDPPolicyID = util.Ptr("policyidudp-gone")
+				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
+
+				Expect(k8sClient.Delete(ctx, nbpolicy)).To(Succeed())
+
+				mux.HandleFunc("/api/policies/policyidtcp-gone", func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusNotFound)
+						_, err := w.Write([]byte(`{"message":"policy: policyidtcp-gone not found","code":404}`))
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+
+				mux.HandleFunc("/api/policies/policyidudp-gone", func(w http.ResponseWriter, r *http.Request) {
+					if r.Method == http.MethodDelete {
+						w.WriteHeader(http.StatusNotFound)
+						_, err := w.Write([]byte(`{"message":"policy: policyidudp-gone not found","code":404}`))
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = k8sClient.Get(ctx, typeNamespacedName, nbpolicy)
+				Expect(errors.IsNotFound(err)).To(BeTrue())
+			})
+		})
 	})
 })


### PR DESCRIPTION
## Summary

Fix reversed `strings.Contains` arguments in `NBPolicyReconciler.handleDelete()`, which prevented finalizer removal when NetBird API policies were already deleted.

## Bug

In [`nbpolicy_controller.go` handleDelete](https://github.com/netbirdio/kubernetes-operator/blob/main/internal/controller/nbpolicy_controller.go#L353-L360), the `strings.Contains` arguments are reversed:

```go
// Before (broken):
if err != nil && !strings.Contains("not found", err.Error()) {
    return err
}
```

`strings.Contains(s, substr)` checks if `substr` is within `s`. Here `s` is the short literal `"not found"` and `substr` is the full error message (e.g. `"policy: d67giu5sqn6c738861m0 not found"`). Since a longer string can never be a substring of a shorter one, this **always returns false**, making the `!` negate to `true`, so every "not found" error is treated as a real failure.

```go
// After (fixed):
if err != nil && !strings.Contains(err.Error(), "not found") {
    return err
}
```

Note: the same pattern is used correctly in [`updatePolicy`](https://github.com/netbirdio/kubernetes-operator/blob/main/internal/controller/nbpolicy_controller.go#L182) — only `handleDelete` had it reversed.

## Impact

When a policy is deleted from the NetBird UI/API **before** the Kubernetes `NBPolicy` CRD is deleted:
1. `handleDelete` calls the NetBird API to delete the policy
2. The API responds with a "not found" error (the policy is already gone)
3. Due to the reversed arguments, the "not found" check fails
4. The error is returned, preventing the `netbird.io/cleanup` finalizer from being removed
5. The `NBPolicy` CRD **cannot be garbage collected** and the controller retries indefinitely with exponential backoff

This leads to a continuous loop of reconciliation errors in the operator logs:
```
ERROR  Reconciler error  {"controller": "nbpolicy", ..., "error": "policy: d67giu5sqn6c738861m0 not found"}
```

## Changes

- **`internal/controller/nbpolicy_controller.go`**: Swap `strings.Contains` arguments for both TCP and UDP policy deletion in `handleDelete`
- **`internal/controller/nbpolicy_controller_test.go`**: Add test case for deletion when policies are already gone from the API (404 response)