### PR TITLE
fix: prevent duplicate managedServiceList entries and destination group IDs

### DIFF
--- a/internal/controller/nbpolicy_controller.go
+++ b/internal/controller/nbpolicy_controller.go
@@ -92,8 +92,12 @@ func (r *NBPolicyReconciler) mapResources(ctx context.Context, nbPolicy *netbird
 		if generatedBy != "" && !util.Contains(resourcePolicies, strings.ReplaceAll(nbPolicy.Name, "-"+generatedBy, "")) {
 			continue
 		}
-		// Groups
-		groups = append(groups, resource.Status.Groups...)
+		// Groups (deduplicate to avoid duplicate destination group IDs)
+		for _, g := range resource.Status.Groups {
+			if !util.Contains(groups, g) {
+				groups = append(groups, g)
+			}
+		}
 
 		for _, p := range resource.Spec.TCPPorts {
 			portMapping[protocolTCP][p] = nil

--- a/internal/controller/nbpolicy_controller.go
+++ b/internal/controller/nbpolicy_controller.go
@@ -390,9 +390,14 @@ func (r *NBPolicyReconciler) groupNamesToIDs(ctx context.Context, groupNames []s
 		groupNameIDMapping[g.Name] = g.Id
 	}
 
+	seen := make(map[string]bool)
 	ret := make([]string, 0, len(groupNames))
 	for _, g := range groupNames {
-		ret = append(ret, groupNameIDMapping[g])
+		id := groupNameIDMapping[g]
+		if !seen[id] {
+			seen[id] = true
+			ret = append(ret, id)
+		}
 	}
 
 	return ret, nil

--- a/internal/controller/nbpolicy_controller_test.go
+++ b/internal/controller/nbpolicy_controller_test.go
@@ -643,5 +643,94 @@ var _ = Describe("NBPolicy Controller", func() {
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			})
 		})
+
+		When("managedServiceList has duplicates", func() {
+			It("should deduplicate destinations via mapResources", func() {
+				controllerReconciler := &NBPolicyReconciler{
+					Client:      k8sClient,
+					Scheme:      k8sClient.Scheme(),
+					netbird:     netbirdClient,
+					ClusterName: "Kubernetes",
+				}
+
+				// Add annotations to the pre-created nbpolicy
+				nbpolicy.Annotations = map[string]string{
+					"netbird.io/generated-by": "default/test",
+				}
+				Expect(k8sClient.Update(ctx, nbpolicy)).To(Succeed())
+
+				nbResource := &netbirdiov1.NBResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "default",
+					},
+					Spec: netbirdiov1.NBResourceSpec{
+						Name:       "meow",
+						Groups:     []string{"test"},
+						NetworkID:  "test",
+						Address:    "test.default.svc.cluster.local",
+						PolicyName: resourceName,
+						TCPPorts:   []int32{443},
+					},
+				}
+				Expect(k8sClient.Create(ctx, nbResource)).To(Succeed())
+
+				nbResource.Status = netbirdiov1.NBResourceStatus{
+					TCPPorts:   []int32{443},
+					PolicyName: &resourceName,
+					Groups:     []string{"groupid1"},
+				}
+				Expect(k8sClient.Status().Update(ctx, nbResource)).To(Succeed())
+
+				// Simulate the duplicate in managedServiceList
+				nbpolicy.Status.ManagedServiceList = []string{"default/test", "default/test"}
+				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
+
+				mux.HandleFunc("/api/groups", func(w http.ResponseWriter, r *http.Request) {
+					resp := []api.Group{
+						{
+							Id:   "meow",
+							Name: "All",
+						},
+					}
+					bs, err := json.Marshal(resp)
+					Expect(err).NotTo(HaveOccurred())
+					_, err = w.Write(bs)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				policyCreated := false
+				mux.HandleFunc("/api/policies", func(w http.ResponseWriter, r *http.Request) {
+					defer GinkgoRecover()
+					if r.Method == http.MethodPost {
+						var policyReq api.PostApiPoliciesJSONRequestBody
+						bs, err := io.ReadAll(r.Body)
+						Expect(err).NotTo(HaveOccurred())
+						err = json.Unmarshal(bs, &policyReq)
+						Expect(err).NotTo(HaveOccurred())
+
+						// Destinations must not be duplicated
+						Expect(policyReq.Rules[0].Destinations).NotTo(BeNil())
+						Expect(*policyReq.Rules[0].Destinations).To(HaveLen(1))
+						Expect((*policyReq.Rules[0].Destinations)[0]).To(Equal("groupid1"))
+
+						policyCreated = true
+						resp := api.Policy{
+							Id: &resourceName,
+						}
+						bs, err = json.Marshal(resp)
+						Expect(err).NotTo(HaveOccurred())
+						_, err = w.Write(bs)
+						Expect(err).NotTo(HaveOccurred())
+					}
+				})
+
+				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: typeNamespacedName,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(policyCreated).To(BeTrue())
+			})
+		})
 	})
 })

--- a/internal/controller/nbresource_controller.go
+++ b/internal/controller/nbresource_controller.go
@@ -188,7 +188,9 @@ func (r *NBResourceReconciler) handlePolicyCreate(ctx context.Context, nbResourc
 	nbResource.Status.PolicySourceGroups = nbResource.Spec.PolicySourceGroups
 	nbResource.Status.PolicyFriendlyName = nbResource.Spec.PolicyFriendlyName
 
-	nbPolicy.Status.ManagedServiceList = append(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String())
+	if !util.Contains(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String()) {
+		nbPolicy.Status.ManagedServiceList = append(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String())
+	}
 	err = r.Client.Status().Update(ctx, nbPolicy)
 	if err != nil {
 		logger.Error(errKubernetesAPI, "err", err)

--- a/internal/controller/nbresource_controller.go
+++ b/internal/controller/nbresource_controller.go
@@ -190,11 +190,11 @@ func (r *NBResourceReconciler) handlePolicyCreate(ctx context.Context, nbResourc
 
 	if !util.Contains(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String()) {
 		nbPolicy.Status.ManagedServiceList = append(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String())
-	}
-	err = r.Client.Status().Update(ctx, nbPolicy)
-	if err != nil {
-		logger.Error(errKubernetesAPI, "err", err)
-		return err
+		err = r.Client.Status().Update(ctx, nbPolicy)
+		if err != nil {
+			logger.Error(errKubernetesAPI, "err", err)
+			return err
+		}
 	}
 	return nil
 }

--- a/internal/controller/nbresource_controller_test.go
+++ b/internal/controller/nbresource_controller_test.go
@@ -528,6 +528,48 @@ var _ = Describe("NBResource Controller", func() {
 								})
 							})
 
+							When("Policy already exists with service in managedServiceList", func() {
+								It("should not duplicate the entry", func() {
+									// Simulate: NBPolicy was created with this service already in managedServiceList
+									// (e.g., a previous reconcile succeeded but the NBResource status update failed,
+									// causing a retry that enters handlePolicyCreate → AlreadyExists)
+									nbPolicy := &netbirdiov1.NBPolicy{
+										ObjectMeta: metav1.ObjectMeta{
+											Name: "test-gen-default-test-resource",
+										},
+										Spec: netbirdiov1.NBPolicySpec{
+											Name:          "Test",
+											Description:   "Test",
+											SourceGroups:  []string{"toast"},
+											Bidirectional: false,
+										},
+									}
+									Expect(k8sClient.Create(ctx, nbPolicy)).To(Succeed())
+
+									// Pre-populate managedServiceList with the service
+									nbPolicy.Status.ManagedServiceList = []string{"default/test-resource"}
+									Expect(k8sClient.Status().Update(ctx, nbPolicy)).To(Succeed())
+
+									nbresource.Spec.PolicyName = policyGenName
+									nbresource.Spec.PolicySourceGroups = []string{"test"}
+									Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
+
+									_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+										NamespacedName: typeNamespacedName,
+									})
+									Expect(err).NotTo(HaveOccurred())
+
+									Expect(k8sClient.Get(ctx, typeNamespacedName, nbresource)).To(Succeed())
+									Expect(nbresource.Status.PolicyNameMapping).To(HaveKey(policyGenName))
+
+									nbPolicy = &netbirdiov1.NBPolicy{}
+									Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nbresource.Status.PolicyNameMapping[policyGenName]}, nbPolicy)).To(Succeed())
+									// Must have exactly 1 entry, not duplicated
+									Expect(nbPolicy.Status.ManagedServiceList).To(HaveLen(1))
+									Expect(nbPolicy.Status.ManagedServiceList[0]).To(Equal("default/test-resource"))
+								})
+							})
+
 							When("Policy settings are updated", func() {
 								It("should update it", func() {
 									nbresource.Spec.PolicyName = policyGenName


### PR DESCRIPTION
## Problem

When service annotations trigger automatic policy creation (`AllowAutomaticPolicyCreation=true`), `handlePolicyCreate` unconditionally appends to `ManagedServiceList`:

```go
// handlePolicyCreate (line 191) — NO guard
nbPolicy.Status.ManagedServiceList = append(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String())
```

In contrast, `handlePolicyAddUpdate` (line 222) correctly checks first:

```go
// handlePolicyAddUpdate — has guard
if !util.Contains(nbPolicy.Status.ManagedServiceList, req.NamespacedName.String()) {
    nbPolicy.Status.ManagedServiceList = append(...)
}
```

### How duplicates are produced

1. **Reconcile #1**: NBResource reconciler enters `handlePolicyCreate` → creates NBPolicy → sets `PolicyNameMapping` in memory → appends to `ManagedServiceList` → `Status().Update()` on NBPolicy succeeds → **deferred** `Status().Update()` on NBResource **fails** (conflict) → `PolicyNameMapping` is NOT persisted
2. **Reconcile #2** (retry): `PolicyNameMapping` is nil → falls back to raw policy name → NBPolicy `IsNotFound` → enters `handlePolicyCreate` again → `Create()` returns `AlreadyExists` → `Get()` retrieves existing NBPolicy (which already has the service in `ManagedServiceList`) → **unconditional append** → `ManagedServiceList = ["svc", "svc"]` — **duplicate**

### Consequences

- `mapResources` iterates the duplicated list, fetching the same NBResource twice
- `groups = append(groups, resource.Status.Groups...)` appends duplicate destination group IDs
- The NetBird API receives a policy with duplicate destinations

## Fix

1. **Root cause** (`nbresource_controller.go`): Add `util.Contains` guard in `handlePolicyCreate`, matching the existing pattern in `handlePolicyAddUpdate`
2. **Defense in depth** (`nbpolicy_controller.go`): Add `util.Contains` check in `mapResources` before appending destination group IDs

## Tests

- `nbresource_controller_test.go`: "Policy already exists with service in managedServiceList" — verifies `handlePolicyCreate` does not duplicate entries on the `AlreadyExists` retry path
- `nbpolicy_controller_test.go`: "managedServiceList has duplicates" — verifies `mapResources` deduplicates destination group IDs even if duplicates exist in the list