### PR TITLE
NBRoutingPeer spec.annotations not correctly applied to pod

### DIFF
--- a/internal/controller/nbroutingpeer_controller.go
+++ b/internal/controller/nbroutingpeer_controller.go
@@ -150,7 +150,6 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 					},
 				},
 				Labels:      labels,
-				Annotations: nbrp.Spec.Annotations,
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: &replicas,
@@ -162,6 +161,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: v1.ObjectMeta{
 						Labels: podLabels,
+						Annotations: nbrp.Spec.Annotations,
 					},
 					Spec: corev1.PodSpec{
 						NodeSelector: nbrp.Spec.NodeSelector,
@@ -219,7 +219,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 		}
 		updatedDeployment.ObjectMeta.Labels = labels
 		for k, v := range nbrp.Spec.Annotations {
-			updatedDeployment.ObjectMeta.Annotations[k] = nbrp.Spec.Annotations[v]
+			updatedDeployment.ObjectMeta.Annotations[k] = v
 		}
 		var replicas int32 = 3
 		if nbrp.Spec.Replicas != nil {
@@ -234,6 +234,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 		updatedDeployment.Spec.Template.Spec.Tolerations = nbrp.Spec.Tolerations
 		updatedDeployment.Spec.Template.Spec.NodeSelector = nbrp.Spec.NodeSelector
 		updatedDeployment.Spec.Template.ObjectMeta.Labels = podLabels
+		updatedDeployment.Spec.Template.ObjectMeta.Annotations = nbrp.Spec.Annotations
 		updatedDeployment.Spec.Template.Spec.Volumes = nbrp.Spec.Volumes
 		if len(updatedDeployment.Spec.Template.Spec.Containers) != 1 {
 			updatedDeployment.Spec.Template.Spec.Containers = []corev1.Container{{}}


### PR DESCRIPTION
Annotations are applied as deployment metadata, not on pod metadata.