### PR TITLE
Update dependabot to run weekly

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -3,13 +3,17 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 15
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: "gomod"
     directories:
       - "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     open-pull-requests-limit: 15
     groups:
       k8s:


### PR DESCRIPTION
This change updates the dependabot interval to run weekly. It also groups all Github Actions update into a single PR. This will make dependency updates a bit easier to manage without spamming too many PRs.