### PR TITLE
Add validation of setup key duration

### DIFF
--- a/api/v1alpha1/setupkey_types.go
+++ b/api/v1alpha1/setupkey_types.go
@@ -15,8 +15,10 @@ type SetupKeySpec struct {
 	Ephemeral bool `json:"ephemeral"`
 
 	// Duration sets how long the setup key is valid for.
-	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="duration is immutable"
 	// +optional
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Pattern="^([0-9]+(\\.[0-9]+)?(m|h))+$"
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="duration is immutable"
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// AutoGroups are groups that will be automatically assigned to peers using setup key.

--- a/examples/refactor/setup-key.yaml
+++ b/examples/refactor/setup-key.yaml
@@ -2,6 +2,7 @@ apiVersion: netbird.io/v1alpha1
 kind: SetupKey
 metadata:
   name: test
-  namespace: netbird
+  namespace: default
 spec:
   name: test
+  ephemeral: true

--- a/helm/kubernetes-operator/crds/netbird.io_setupkeys.yaml
+++ b/helm/kubernetes-operator/crds/netbird.io_setupkeys.yaml
@@ -77,6 +77,7 @@ spec:
                 type: array
               duration:
                 description: Duration sets how long the setup key is valid for.
+                pattern: ^([0-9]+(\.[0-9]+)?(m|h))+$
                 type: string
                 x-kubernetes-validations:
                 - message: duration is immutable


### PR DESCRIPTION
This adds more validation to the setup key duration to make sure the unit and format is correct.