### PR TITLE
Add path component to finalizer

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -1,7 +1,5 @@
 package v1alpha1
 
-const NetbirdFinalizer = "finalizers.netbird.io"
-
 const ReadyCondition = "Ready"
 
 const (

--- a/internal/controller/gateway_controller.go
+++ b/internal/controller/gateway_controller.go
@@ -33,6 +33,7 @@ import (
 
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
 	"github.com/netbirdio/kubernetes-operator/internal/gatewayutil"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 )
 
 type GatewayReconciler struct {
@@ -90,7 +91,7 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		Reason: string(gatewayv1.GatewayReasonAccepted),
 	}
 	meta.SetStatusCondition(&gw.Status.Conditions, cond)
-	controllerutil.AddFinalizer(gw, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(gw, k8sutil.Finalizer("gateway"))
 	err = sp.Patch(ctx, gw)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -158,7 +159,7 @@ func (r *GatewayReconciler) reconcileDelete(ctx context.Context, sp *patch.Seria
 		}
 	}
 
-	controllerutil.RemoveFinalizer(gw, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(gw, k8sutil.Finalizer("gateway"))
 	err = sp.Patch(ctx, gw)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/gatewayclass_controller.go
+++ b/internal/controller/gatewayclass_controller.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/fluxcd/pkg/runtime/patch"
-	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -66,7 +66,7 @@ func (r *GatewayClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Set condition to accepted.
-	controllerutil.AddFinalizer(gwc, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(gwc, k8sutil.Finalizer("gatewayclass"))
 	cond := metav1.Condition{
 		Type:    string(gatewayv1.GatewayClassConditionStatusAccepted),
 		Status:  metav1.ConditionTrue,
@@ -93,7 +93,7 @@ func (r *GatewayClassReconciler) reconcileDelete(ctx context.Context, sp *patch.
 		}
 	}
 
-	controllerutil.RemoveFinalizer(gwc, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(gwc, k8sutil.Finalizer("gatewayclass"))
 	err = sp.Patch(ctx, gwc)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 )
 
 type GroupReconciler struct {
@@ -35,7 +36,7 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return r.reconcileDelete(ctx, sp, group)
 	}
 
-	controllerutil.AddFinalizer(group, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(group, k8sutil.Finalizer("group"))
 	err = sp.Patch(ctx, group)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -81,7 +82,7 @@ func (r *GroupReconciler) reconcileDelete(ctx context.Context, sp *patch.SerialP
 		}
 	}
 
-	controllerutil.RemoveFinalizer(group, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(group, k8sutil.Finalizer("group"))
 	err := sp.Patch(ctx, group)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -19,7 +19,7 @@ import (
 
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
 	"github.com/netbirdio/kubernetes-operator/internal/gatewayutil"
-	"github.com/netbirdio/kubernetes-operator/internal/ssautil"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	"github.com/netbirdio/kubernetes-operator/internal/util"
 	nbv1alpha1ac "github.com/netbirdio/kubernetes-operator/pkg/applyconfigurations/api/v1alpha1"
 )
@@ -66,7 +66,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, err
 		}
 
-		controllerutil.AddFinalizer(hr, nbv1alpha1.NetbirdFinalizer)
+		controllerutil.AddFinalizer(hr, k8sutil.Finalizer("httproute"))
 		err = sp.Patch(ctx, hr)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -87,12 +87,12 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		}
 
 		for _, svc := range svcIdx {
-			controllerRef, err := ssautil.ControllerReference(&svc, r.Scheme())
+			controllerRef, err := k8sutil.ControllerReference(&svc, r.Scheme())
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 			controllerRef = controllerRef.WithBlockOwnerDeletion(false)
-			ownerRef, err := ssautil.OwnerReference(hr, r.Scheme())
+			ownerRef, err := k8sutil.OwnerReference(hr, r.Scheme())
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -255,7 +255,7 @@ func (r *HTTPRouteReconciler) reconcileDelete(ctx context.Context, sp *patch.Ser
 		}
 	}
 
-	controllerutil.RemoveFinalizer(hr, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(hr, k8sutil.Finalizer("httproute"))
 	err = sp.Patch(ctx, hr)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/networkresource_controller.go
+++ b/internal/controller/networkresource_controller.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	"github.com/netbirdio/kubernetes-operator/internal/netbirdutil"
 )
 
@@ -117,7 +118,7 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	controllerutil.AddFinalizer(netResource, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(netResource, k8sutil.Finalizer("networkresource"))
 
 	resourceID, err := func() (string, error) {
 		netReq := api.NetworkResourceRequest{
@@ -218,7 +219,7 @@ func (r *NetworkResourceReconciler) reconcileDelete(ctx context.Context, sp *pat
 		}
 	}
 
-	controllerutil.RemoveFinalizer(netResource, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(netResource, k8sutil.Finalizer("networkresource"))
 	err := sp.Patch(ctx, netResource)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/networkrouter_controller.go
+++ b/internal/controller/networkrouter_controller.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/fluxcd/pkg/runtime/patch"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	"github.com/netbirdio/kubernetes-operator/internal/netbirdutil"
-	"github.com/netbirdio/kubernetes-operator/internal/ssautil"
 	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
 	"github.com/netbirdio/netbird/shared/management/http/api"
 	appsv1 "k8s.io/api/apps/v1"
@@ -55,7 +55,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return r.reconcileDelete(ctx, sp, netRouter)
 	}
 
-	ownerRef, err := ssautil.ControllerReference(netRouter, r.Scheme())
+	ownerRef, err := k8sutil.ControllerReference(netRouter, r.Scheme())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -66,7 +66,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	controllerutil.AddFinalizer(netRouter, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(netRouter, k8sutil.Finalizer("networkrouter"))
 
 	networkID, err := func() (string, error) {
 		networkReq := api.NetworkRequest{
@@ -304,7 +304,7 @@ func (r *NetworkRouterReconciler) reconcileDelete(ctx context.Context, sp *patch
 		}
 	}
 
-	controllerutil.RemoveFinalizer(netRouter, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(netRouter, k8sutil.Finalizer("networkrouter"))
 	err := sp.Patch(ctx, netRouter)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/setupkey_controller.go
+++ b/internal/controller/setupkey_controller.go
@@ -18,8 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	"github.com/netbirdio/kubernetes-operator/internal/netbirdutil"
-	"github.com/netbirdio/kubernetes-operator/internal/ssautil"
 )
 
 const (
@@ -41,7 +41,7 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	owner, err := ssautil.ControllerReference(setupKey, r.Client.Scheme())
+	owner, err := k8sutil.ControllerReference(setupKey, r.Client.Scheme())
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -56,7 +56,7 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
-	controllerutil.AddFinalizer(setupKey, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.AddFinalizer(setupKey, k8sutil.Finalizer("setupkey"))
 	err = sp.Patch(ctx, setupKey)
 	if err != nil {
 		return ctrl.Result{}, err
@@ -177,7 +177,7 @@ func (r *SetupKeyReconciler) reconcileDelete(ctx context.Context, sp *patch.Seri
 		}
 	}
 
-	controllerutil.RemoveFinalizer(setupKey, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(setupKey, k8sutil.Finalizer("setupkey"))
 	err := sp.Patch(ctx, setupKey)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -16,7 +16,7 @@ import (
 	"github.com/fluxcd/pkg/runtime/patch"
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
 	"github.com/netbirdio/kubernetes-operator/internal/gatewayutil"
-	"github.com/netbirdio/kubernetes-operator/internal/ssautil"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
 	nbv1alpha1ac "github.com/netbirdio/kubernetes-operator/pkg/applyconfigurations/api/v1alpha1"
 )
 
@@ -56,7 +56,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			return ctrl.Result{}, err
 		}
 
-		controllerutil.AddFinalizer(tr, nbv1alpha1.NetbirdFinalizer)
+		controllerutil.AddFinalizer(tr, k8sutil.Finalizer("tcproute"))
 		err = sp.Patch(ctx, tr)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -77,12 +77,12 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		}
 
 		for _, svc := range svcIdx {
-			controllerRef, err := ssautil.ControllerReference(&svc, r.Scheme())
+			controllerRef, err := k8sutil.ControllerReference(&svc, r.Scheme())
 			if err != nil {
 				return ctrl.Result{}, err
 			}
 			controllerRef = controllerRef.WithBlockOwnerDeletion(false)
-			ownerRef, err := ssautil.OwnerReference(tr, r.Scheme())
+			ownerRef, err := k8sutil.OwnerReference(tr, r.Scheme())
 			if err != nil {
 				return ctrl.Result{}, err
 			}
@@ -159,7 +159,7 @@ func (r *TCPRouteReconciler) reconcileDelete(ctx context.Context, sp *patch.Seri
 		}
 	}
 
-	controllerutil.RemoveFinalizer(tr, nbv1alpha1.NetbirdFinalizer)
+	controllerutil.RemoveFinalizer(tr, k8sutil.Finalizer("tcproute"))
 	err := sp.Patch(ctx, tr)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/k8sutil/finalizer.go
+++ b/internal/k8sutil/finalizer.go
@@ -1,0 +1,7 @@
+package k8sutil
+
+const NetbirdFinalizer = "finalizers.netbird.io"
+
+func Finalizer(kind string) string {
+	return NetbirdFinalizer + "/" + kind
+}

--- a/internal/k8sutil/owner.go
+++ b/internal/k8sutil/owner.go
@@ -1,4 +1,4 @@
-package ssautil
+package k8sutil
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
The Kubernetes client warns about not having a path component in the finalizer. This change adds a unqiue path component for each reconciler kind.