### PR TITLE
Refactor Dockerfile to build Go binary outside of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.so
 *.dylib
 bin/*
-Dockerfile.cross
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,5 @@
-# This dockerfile is used for tests and local builds
-
-# Build the manager binary
-FROM docker.io/golang:1.26 AS builder
-ARG TARGETOS
-ARG TARGETARCH
-
-WORKDIR /workspace
-# Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
-
-# Copy the go source
-COPY cmd/main.go cmd/main.go
-COPY api/ api/
-COPY internal/ internal/
-COPY pkg/ pkg/
-
-# Build
-# the GOARCH has not a default value to allow the binary be built according to the host where the command
-# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
-# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
-# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -ldflags="-w -s" -a -o manager cmd/main.go
-
-# Use distroless as minimal base image to package the manager binary
-# Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /
-COPY --from=builder /workspace/manager .
+COPY manager .
 USER 65532:65532
-
 ENTRYPOINT ["/manager"]

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,8 +1,0 @@
-# This dockerfile is used for goreleaser
-
-FROM gcr.io/distroless/static:nonroot
-WORKDIR /
-COPY manager .
-USER 65532:65532
-
-ENTRYPOINT ["/manager"]

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netbirdio/kubernetes-operator
 
 go 1.25.5
 
-toolchain go1.26.1
+toolchain go1.26.2
 
 require (
 	github.com/fluxcd/pkg/runtime v0.105.0


### PR DESCRIPTION
We want to standardize how the controller binary is built. This change refactors the build to run outside of Docker and use the toolchain version specified in go.mod as the Go version used to build the binary.  