### PR TITLE
Fix group reconcile removing peers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,29 +76,17 @@ build-installer: generate
 
 ##@ Deployment
 
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
-## Install CRDs into the K8s cluster specified in ~/.kube/config.
 .PHONY: install
 install: generate
 	kubectl apply --server-side -f helm/kubernetes-operator/crds
 
-## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
 .PHONY: uninstall
-uninstall: generate
+uninstall:
 	kubectl delete -f helm/kubernetes-operator/crds
 
-## Deploy controller to the K8s cluster specified in ~/.kube/config.
-.PHONY: deploy
-deploy: genereate
-	helm install -n netbird --create-namespace kubernetes-operator --set operator.image.tag=$(word 2,$(subst :, ,${IMG})) helm/kubernetes-operator
-
-## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-.PHONY: undeploy
-undeploy:
-	helm uninstall -n netbird kubernetes-operator
+run: install
+	kubectl create namespace netbird --dry-run=client -o yaml | kubectl apply -f -
+	go run cmd/main.go --enable-webhooks=false --netbird-api-key=$${NB_API_KEY}  --runtime-namespace netbird
 
 ##@ Dependencies
 

--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/fluxcd/pkg/runtime/patch"
@@ -25,6 +26,7 @@ type GroupReconciler struct {
 // +kubebuilder:rbac:groups=netbird.io,resources=groups,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=netbird.io,resources=groups/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=netbird.io,resources=groups/finalizers,verbs=update
+
 func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	group := &nbv1alpha1.Group{}
 	err := r.Get(ctx, req.NamespacedName, group)
@@ -44,17 +46,29 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	groupID, err := func() (string, error) {
+		if group.Status.GroupID != "" {
+			groupResp, err := r.Netbird.Groups.Get(ctx, group.Status.GroupID)
+			if err == nil {
+				peers := []string{}
+				for _, peer := range groupResp.Peers {
+					peers = append(peers, peer.Id)
+				}
+				groupReq := api.GroupRequest{
+					Name:      group.Spec.Name,
+					Peers:     &peers,
+					Resources: &groupResp.Resources,
+				}
+				resp, err := r.Netbird.Groups.Update(ctx, group.Status.GroupID, groupReq)
+				if err != nil && !netbird.IsNotFound(err) {
+					return "", err
+				}
+				if err == nil {
+					return resp.Id, nil
+				}
+			}
+		}
 		groupReq := api.GroupRequest{
 			Name: group.Spec.Name,
-		}
-		if group.Status.GroupID != "" {
-			resp, err := r.Netbird.Groups.Update(ctx, group.Status.GroupID, groupReq)
-			if err != nil && !netbird.IsNotFound(err) {
-				return "", err
-			}
-			if err == nil {
-				return resp.Id, nil
-			}
 		}
 		resp, err := r.Netbird.Groups.Create(ctx, groupReq)
 		if err != nil {
@@ -72,7 +86,7 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: 15 * time.Minute}, nil
 }
 
 func (r *GroupReconciler) reconcileDelete(ctx context.Context, sp *patch.SerialPatcher, group *nbv1alpha1.Group) (ctrl.Result, error) {
@@ -91,7 +105,6 @@ func (r *GroupReconciler) reconcileDelete(ctx context.Context, sp *patch.SerialP
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager sets up the controller with the Manager.
 func (r *GroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nbv1alpha1.Group{}).


### PR DESCRIPTION
This changes the group reconcile to get the existing group first and then update it in place. If not done like this peers will be removed from the group on the next reconcile.

Fixes #221