### PR TITLE
Modernize for Go 1.26

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.0
 	sigs.k8s.io/gateway-api v1.5.1
 	sigs.k8s.io/structured-merge-diff/v6 v6.4.0
@@ -103,6 +102,7 @@ require (
 	k8s.io/gengo/v2 v2.0.0-20250922181213-ec3ebc5fd46b // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/controller-tools v0.20.1 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -23,7 +23,6 @@ import (
 	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
 	"github.com/netbirdio/kubernetes-operator/internal/gatewayutil"
 	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 	nbv1alpha1ac "github.com/netbirdio/kubernetes-operator/pkg/applyconfigurations/api/v1alpha1"
 )
 
@@ -148,9 +147,9 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Domain:           string(hostname),
 				Enabled:          true,
 				Name:             string(hostname),
-				Mode:             util.Ptr(api.ServiceRequestModeHttp),
-				PassHostHeader:   util.Ptr(false),
-				RewriteRedirects: util.Ptr(false),
+				Mode:             new(api.ServiceRequestModeHttp),
+				PassHostHeader:   new(false),
+				RewriteRedirects: new(false),
 				Targets:          &targets,
 			}
 

--- a/internal/controller/nbgroup_controller_test.go
+++ b/internal/controller/nbgroup_controller_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/netbirdio/netbird/shared/management/http/api"
 
 	nbv1 "github.com/netbirdio/kubernetes-operator/api/v1"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 )
 
 var _ = Describe("NBGroup Controller", func() {
@@ -160,7 +159,7 @@ var _ = Describe("NBGroup Controller", func() {
 			deleteGroup := func() {
 				GinkgoHelper()
 				By("Adding the group ID in status")
-				nbGroup.Status.GroupID = util.Ptr("Test")
+				nbGroup.Status.GroupID = new("Test")
 				err := k8sClient.Status().Update(ctx, &nbGroup)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -285,7 +284,7 @@ var _ = Describe("NBGroup Controller", func() {
 					Expect(err).NotTo(HaveOccurred())
 				})
 
-				nbGroup.Status.GroupID = util.Ptr("Toast")
+				nbGroup.Status.GroupID = new("Toast")
 				Expect(k8sClient.Status().Update(ctx, &nbGroup)).To(Succeed())
 
 				_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -329,7 +328,7 @@ var _ = Describe("NBGroup Controller", func() {
 					}
 				})
 
-				nbGroup.Status.GroupID = util.Ptr("Toast")
+				nbGroup.Status.GroupID = new("Toast")
 				Expect(k8sClient.Status().Update(ctx, &nbGroup)).To(Succeed())
 
 				res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{

--- a/internal/controller/nbpolicy_controller_test.go
+++ b/internal/controller/nbpolicy_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/netbirdio/netbird/shared/management/http/api"
 
 	nbv1 "github.com/netbirdio/kubernetes-operator/api/v1"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 )
 
 var _ = Describe("NBPolicy Controller", func() {
@@ -171,13 +170,13 @@ var _ = Describe("NBPolicy Controller", func() {
 						err = json.Unmarshal(bs, &policyReq)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(policyReq.Name).To(Equal("Test TCP"))
-						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Enabled).To(BeTrue())
 						Expect(policyReq.SourcePostureChecks).To(BeNil())
 						Expect(policyReq.Rules).To(HaveLen(1))
 						Expect(policyReq.Rules[0].Action).To(BeEquivalentTo(api.PolicyRuleActionAccept))
 						Expect(policyReq.Rules[0].Bidirectional).To(BeTrue())
-						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Rules[0].DestinationResource).To(BeNil())
 						Expect(policyReq.Rules[0].Destinations).NotTo(BeNil())
 						Expect(*policyReq.Rules[0].Destinations).To(HaveLen(1))
@@ -220,7 +219,7 @@ var _ = Describe("NBPolicy Controller", func() {
 				}
 
 				nbpolicy.Status.ManagedServiceList = append(nbpolicy.Status.ManagedServiceList, "default/noexist")
-				nbpolicy.Status.TCPPolicyID = util.Ptr("policyid")
+				nbpolicy.Status.TCPPolicyID = new("policyid")
 				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
 
 				mux.HandleFunc("/api/groups", func(w http.ResponseWriter, r *http.Request) {
@@ -309,13 +308,13 @@ var _ = Describe("NBPolicy Controller", func() {
 						err = json.Unmarshal(bs, &policyReq)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(policyReq.Name).To(Equal("Test UDP"))
-						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Enabled).To(BeTrue())
 						Expect(policyReq.SourcePostureChecks).To(BeNil())
 						Expect(policyReq.Rules).To(HaveLen(1))
 						Expect(policyReq.Rules[0].Action).To(BeEquivalentTo(api.PolicyRuleActionAccept))
 						Expect(policyReq.Rules[0].Bidirectional).To(BeTrue())
-						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Rules[0].DestinationResource).To(BeNil())
 						Expect(policyReq.Rules[0].Destinations).NotTo(BeNil())
 						Expect(*policyReq.Rules[0].Destinations).To(HaveLen(1))
@@ -358,7 +357,7 @@ var _ = Describe("NBPolicy Controller", func() {
 				}
 
 				nbpolicy.Status.ManagedServiceList = append(nbpolicy.Status.ManagedServiceList, "default/noexist")
-				nbpolicy.Status.UDPPolicyID = util.Ptr("policyid")
+				nbpolicy.Status.UDPPolicyID = new("policyid")
 				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
 
 				mux.HandleFunc("/api/groups", func(w http.ResponseWriter, r *http.Request) {
@@ -425,7 +424,7 @@ var _ = Describe("NBPolicy Controller", func() {
 				Expect(k8sClient.Update(ctx, nbpolicy)).To(Succeed())
 
 				nbpolicy.Status.ManagedServiceList = append(nbpolicy.Status.ManagedServiceList, "default/test")
-				nbpolicy.Status.TCPPolicyID = util.Ptr("policyid")
+				nbpolicy.Status.TCPPolicyID = new("policyid")
 				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
 
 				mux.HandleFunc("/api/groups", func(w http.ResponseWriter, r *http.Request) {
@@ -524,7 +523,7 @@ var _ = Describe("NBPolicy Controller", func() {
 				Expect(k8sClient.Status().Update(ctx, nbResourceB)).To(Succeed())
 
 				nbpolicy.Status.ManagedServiceList = append(nbpolicy.Status.ManagedServiceList, "default/test", "default/test-b")
-				nbpolicy.Status.TCPPolicyID = util.Ptr("policyid")
+				nbpolicy.Status.TCPPolicyID = new("policyid")
 				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
 
 				mux.HandleFunc("/api/groups", func(w http.ResponseWriter, r *http.Request) {
@@ -552,13 +551,13 @@ var _ = Describe("NBPolicy Controller", func() {
 						err = json.Unmarshal(bs, &policyReq)
 						Expect(err).NotTo(HaveOccurred())
 						Expect(policyReq.Name).To(Equal("Test TCP"))
-						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Enabled).To(BeTrue())
 						Expect(policyReq.SourcePostureChecks).To(BeNil())
 						Expect(policyReq.Rules).To(HaveLen(1))
 						Expect(policyReq.Rules[0].Action).To(BeEquivalentTo(api.PolicyRuleActionAccept))
 						Expect(policyReq.Rules[0].Bidirectional).To(BeTrue())
-						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(util.Ptr(""))))
+						Expect(policyReq.Rules[0].Description).To(Or(BeNil(), BeEquivalentTo(new(""))))
 						Expect(policyReq.Rules[0].DestinationResource).To(BeNil())
 						Expect(policyReq.Rules[0].Destinations).NotTo(BeNil())
 						Expect(*policyReq.Rules[0].Destinations).To(HaveLen(2))
@@ -594,8 +593,8 @@ var _ = Describe("NBPolicy Controller", func() {
 					Netbird: netbirdClient,
 				}
 
-				nbpolicy.Status.TCPPolicyID = util.Ptr("policyidtcp")
-				nbpolicy.Status.UDPPolicyID = util.Ptr("policyidudp")
+				nbpolicy.Status.TCPPolicyID = new("policyidtcp")
+				nbpolicy.Status.UDPPolicyID = new("policyidudp")
 				Expect(k8sClient.Status().Update(ctx, nbpolicy)).To(Succeed())
 
 				Expect(k8sClient.Delete(ctx, nbpolicy)).To(Succeed())

--- a/internal/controller/nbresource_controller.go
+++ b/internal/controller/nbresource_controller.go
@@ -533,7 +533,7 @@ func (r *NBResourceReconciler) handleGroups(ctx context.Context, req ctrl.Reques
 							Kind:               "NBResource",
 							Name:               nbResource.Name,
 							UID:                nbResource.UID,
-							BlockOwnerDeletion: util.Ptr(true),
+							BlockOwnerDeletion: new(true),
 						},
 					},
 					Finalizers: []string{"netbird.io/group-cleanup", "netbird.io/resource-cleanup"},
@@ -566,7 +566,7 @@ func (r *NBResourceReconciler) handleGroups(ctx context.Context, req ctrl.Reques
 					Kind:               "NBResource",
 					Name:               nbResource.Name,
 					UID:                nbResource.UID,
-					BlockOwnerDeletion: util.Ptr(true),
+					BlockOwnerDeletion: new(true),
 				})
 
 				err = r.Client.Update(ctx, &nbGroup)

--- a/internal/controller/nbresource_controller_test.go
+++ b/internal/controller/nbresource_controller_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/netbirdio/netbird/shared/management/http/api"
 
 	nbv1 "github.com/netbirdio/kubernetes-operator/api/v1"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 )
 
 var _ = Describe("NBResource Controller", func() {
@@ -128,7 +127,7 @@ var _ = Describe("NBResource Controller", func() {
 				nbGroup := &nbv1.NBGroup{}
 				Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "meow"}, nbGroup)).To(Succeed())
 				Expect(nbGroup.Labels).To(HaveKeyWithValue("dog", "bark"))
-				nbGroup.Status.GroupID = util.Ptr("test")
+				nbGroup.Status.GroupID = new("test")
 				Expect(k8sClient.Status().Update(ctx, nbGroup)).To(Succeed())
 			})
 
@@ -180,7 +179,7 @@ var _ = Describe("NBResource Controller", func() {
 		})
 		When("Network Resource exists", func() {
 			BeforeEach(func() {
-				nbresource.Status.NetworkResourceID = util.Ptr("test")
+				nbresource.Status.NetworkResourceID = new("test")
 				Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 				nbGroup := &nbv1.NBGroup{
@@ -203,7 +202,7 @@ var _ = Describe("NBResource Controller", func() {
 				}
 				Expect(k8sClient.Create(ctx, nbGroup)).To(Succeed())
 
-				nbGroup.Status.GroupID = util.Ptr("test")
+				nbGroup.Status.GroupID = new("test")
 				Expect(k8sClient.Status().Update(ctx, nbGroup)).To(Succeed())
 			})
 
@@ -282,7 +281,7 @@ var _ = Describe("NBResource Controller", func() {
 						}
 					})
 
-					nbresource.Status.NetworkResourceID = util.Ptr("test")
+					nbresource.Status.NetworkResourceID = new("test")
 					Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 					_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -378,7 +377,7 @@ var _ = Describe("NBResource Controller", func() {
 								nbresource.Spec.PolicyName = "test-b"
 								Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
 
-								nbresource.Status.PolicyName = util.Ptr("test-a")
+								nbresource.Status.PolicyName = new("test-a")
 								Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 								_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -406,7 +405,7 @@ var _ = Describe("NBResource Controller", func() {
 								nbresource.Spec.PolicyName = ""
 								Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
 
-								nbresource.Status.PolicyName = util.Ptr("test-a")
+								nbresource.Status.PolicyName = new("test-a")
 								Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 								_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -705,7 +704,7 @@ var _ = Describe("NBResource Controller", func() {
 							nbresource.Spec.PolicyName = "test-b,test-c"
 							Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
 
-							nbresource.Status.PolicyName = util.Ptr("test-a,test-b")
+							nbresource.Status.PolicyName = new("test-a,test-b")
 							Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 							_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -732,7 +731,7 @@ var _ = Describe("NBResource Controller", func() {
 							nbresource.Spec.PolicyName = ""
 							Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
 
-							nbresource.Status.PolicyName = util.Ptr("test-b,test-c")
+							nbresource.Status.PolicyName = new("test-b,test-c")
 							Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 							_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -870,8 +869,8 @@ var _ = Describe("NBResource Controller", func() {
 				nbresource.Spec.Groups = []string{"meow", "meowdelete"}
 				Expect(k8sClient.Update(ctx, nbresource)).To(Succeed())
 				nbresource.Status.Groups = []string{"test", "testdelete"}
-				nbresource.Status.PolicyName = util.Ptr("test")
-				nbresource.Status.NetworkResourceID = util.Ptr("test")
+				nbresource.Status.PolicyName = new("test")
+				nbresource.Status.NetworkResourceID = new("test")
 				Expect(k8sClient.Status().Update(ctx, nbresource)).To(Succeed())
 
 				nbPolicy := &nbv1.NBPolicy{

--- a/internal/controller/nbroutingpeer_controller.go
+++ b/internal/controller/nbroutingpeer_controller.go
@@ -147,7 +147,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 						Kind:               "NBRoutingPeer",
 						Name:               nbrp.Name,
 						UID:                nbrp.UID,
-						BlockOwnerDeletion: util.Ptr(true),
+						BlockOwnerDeletion: new(true),
 					},
 				},
 				Labels:      labels,
@@ -215,7 +215,7 @@ func (r *NBRoutingPeerReconciler) handleDeployment(ctx context.Context, req ctrl
 				Kind:               "NBRoutingPeer",
 				Name:               nbrp.Name,
 				UID:                nbrp.UID,
-				BlockOwnerDeletion: util.Ptr(true),
+				BlockOwnerDeletion: new(true),
 			},
 		}
 		updatedDeployment.ObjectMeta.Labels = labels
@@ -345,7 +345,7 @@ func (r *NBRoutingPeerReconciler) handleSetupKey(ctx context.Context, req ctrl.R
 		// Create new setup key with group Status.GroupID
 		setupKey, err := r.Netbird.SetupKeys.Create(ctx, api.CreateSetupKeyRequest{
 			AutoGroups: []string{*nbGroup.Status.GroupID},
-			Ephemeral:  util.Ptr(true),
+			Ephemeral:  new(true),
 			Name:       networkName,
 			Type:       "reusable",
 		})
@@ -368,7 +368,7 @@ func (r *NBRoutingPeerReconciler) handleSetupKey(ctx context.Context, req ctrl.R
 						Kind:               "NBRoutingPeer",
 						Name:               nbrp.Name,
 						UID:                nbrp.UID,
-						BlockOwnerDeletion: util.Ptr(true),
+						BlockOwnerDeletion: new(true),
 					},
 				},
 				Labels: r.DefaultLabels,
@@ -478,7 +478,7 @@ func (r *NBRoutingPeerReconciler) handleGroup(ctx context.Context, req ctrl.Requ
 						Kind:               "NBRoutingPeer",
 						Name:               nbrp.Name,
 						UID:                nbrp.UID,
-						BlockOwnerDeletion: util.Ptr(true),
+						BlockOwnerDeletion: new(true),
 					},
 				},
 				Finalizers: []string{"netbird.io/group-cleanup", "netbird.io/routing-peer-cleanup"},

--- a/internal/controller/nbroutingpeer_controller_test.go
+++ b/internal/controller/nbroutingpeer_controller_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/netbirdio/netbird/shared/management/http/api"
 
 	nbv1 "github.com/netbirdio/kubernetes-operator/api/v1"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 )
 
 var _ = Describe("NBRoutingPeer Controller", func() {
@@ -67,7 +66,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						Finalizers: []string{"netbird.io/cleanup"},
 					},
 					Spec: nbv1.NBRoutingPeerSpec{
-						Replicas: util.Ptr(int32(0)),
+						Replicas: new(int32(0)),
 					},
 				}
 				Expect(k8sClient.Create(ctx, nbroutingpeer)).To(Succeed())
@@ -227,7 +226,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 					}
 				})
 
-				nbroutingpeer.Status.NetworkID = util.Ptr("test")
+				nbroutingpeer.Status.NetworkID = new("test")
 				Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 			})
 			Describe("Network Router changes", func() {
@@ -243,10 +242,10 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 					}
 					Expect(k8sClient.Create(ctx, group)).To(Succeed())
 
-					group.Status.GroupID = util.Ptr("test")
+					group.Status.GroupID = new("test")
 					Expect(k8sClient.Status().Update(ctx, group)).To(Succeed())
 
-					nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+					nbroutingpeer.Status.SetupKeyID = new("skid")
 					Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 					mux.HandleFunc("/api/setup-keys/skid", func(w http.ResponseWriter, r *http.Request) {
@@ -324,7 +323,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 				})
 				When("Network Router is out-of-date", func() {
 					It("should update network router", func() {
-						nbroutingpeer.Status.RouterID = util.Ptr("test")
+						nbroutingpeer.Status.RouterID = new("test")
 						Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 						routerUpdated := false
@@ -389,7 +388,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 			})
 			When("Network Router exists", func() {
 				BeforeEach(func() {
-					nbroutingpeer.Status.RouterID = util.Ptr("test")
+					nbroutingpeer.Status.RouterID = new("test")
 					Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 					mux.HandleFunc("/api/networks/test/routers", func(w http.ResponseWriter, r *http.Request) {
@@ -413,7 +412,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 				})
 				When("Group doesn't exist", func() {
 					BeforeEach(func() {
-						nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+						nbroutingpeer.Status.SetupKeyID = new("skid")
 						Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 						mux.HandleFunc("/api/setup-keys/skid", func(w http.ResponseWriter, r *http.Request) {
@@ -452,7 +451,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						Expect(group.Spec.Name).To(Equal(controllerReconciler.ClusterName))
 						Expect(group.Labels).To(HaveKeyWithValue("dog", "bark"))
 
-						group.Status.GroupID = util.Ptr("test")
+						group.Status.GroupID = new("test")
 						Expect(k8sClient.Status().Update(ctx, group)).To(Succeed())
 
 						_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -475,7 +474,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						}
 						Expect(k8sClient.Create(ctx, group)).To(Succeed())
 
-						group.Status.GroupID = util.Ptr("test")
+						group.Status.GroupID = new("test")
 						Expect(k8sClient.Status().Update(ctx, group)).To(Succeed())
 					})
 
@@ -492,7 +491,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 										Expect(err).NotTo(HaveOccurred())
 										Expect(json.Unmarshal(bs, &req)).To(Succeed())
 										Expect(req.AutoGroups).To(ConsistOf([]string{"test"}))
-										Expect(req.Ephemeral).To(BeEquivalentTo(util.Ptr(true)))
+										Expect(req.Ephemeral).To(BeEquivalentTo(new(true)))
 										Expect(req.ExpiresIn).To(BeZero())
 										Expect(req.Name).To(Equal(controllerReconciler.ClusterName))
 										Expect(req.Type).To(Equal("reusable"))
@@ -535,7 +534,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 										Expect(err).NotTo(HaveOccurred())
 										Expect(json.Unmarshal(bs, &req)).To(Succeed())
 										Expect(req.AutoGroups).To(ConsistOf([]string{"test"}))
-										Expect(req.Ephemeral).To(BeEquivalentTo(util.Ptr(true)))
+										Expect(req.Ephemeral).To(BeEquivalentTo(new(true)))
 										Expect(req.ExpiresIn).To(BeZero())
 										Expect(req.Name).To(Equal(controllerReconciler.ClusterName))
 										Expect(req.Type).To(Equal("reusable"))
@@ -575,7 +574,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 									}
 								})
 
-								nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+								nbroutingpeer.Status.SetupKeyID = new("skid")
 								Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 								res, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -609,7 +608,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 										Expect(err).NotTo(HaveOccurred())
 										Expect(json.Unmarshal(bs, &req)).To(Succeed())
 										Expect(req.AutoGroups).To(ConsistOf([]string{"test"}))
-										Expect(req.Ephemeral).To(BeEquivalentTo(util.Ptr(true)))
+										Expect(req.Ephemeral).To(BeEquivalentTo(new(true)))
 										Expect(req.ExpiresIn).To(BeZero())
 										Expect(req.Name).To(Equal(controllerReconciler.ClusterName))
 										Expect(req.Type).To(Equal("reusable"))
@@ -649,7 +648,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 									}
 								})
 
-								nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+								nbroutingpeer.Status.SetupKeyID = new("skid")
 								Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 								secret := &corev1.Secret{
@@ -694,7 +693,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 										Expect(err).NotTo(HaveOccurred())
 										Expect(json.Unmarshal(bs, &req)).To(Succeed())
 										Expect(req.AutoGroups).To(ConsistOf([]string{"test"}))
-										Expect(req.Ephemeral).To(BeEquivalentTo(util.Ptr(true)))
+										Expect(req.Ephemeral).To(BeEquivalentTo(new(true)))
 										Expect(req.ExpiresIn).To(BeZero())
 										Expect(req.Name).To(Equal(controllerReconciler.ClusterName))
 										Expect(req.Type).To(Equal("reusable"))
@@ -729,7 +728,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 									}
 								})
 
-								nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+								nbroutingpeer.Status.SetupKeyID = new("skid")
 								Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 								secret := &corev1.Secret{
@@ -784,7 +783,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 									}
 								})
 
-								nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+								nbroutingpeer.Status.SetupKeyID = new("skid")
 								Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 								secret := &corev1.Secret{
@@ -814,7 +813,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 					})
 					Describe("Deployment Behavior", func() {
 						BeforeEach(func() {
-							nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+							nbroutingpeer.Status.SetupKeyID = new("skid")
 							Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 							mux.HandleFunc("/api/setup-keys/skid", func(w http.ResponseWriter, r *http.Request) {
@@ -851,7 +850,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 								deployment := &appsv1.Deployment{}
 								Expect(k8sClient.Get(ctx, typeNamespacedName, deployment)).To(Succeed())
 								Expect(deployment.OwnerReferences).To(HaveLen(1))
-								Expect(deployment.Spec.Replicas).To(BeEquivalentTo(util.Ptr(int32(0))))
+								Expect(deployment.Spec.Replicas).To(BeEquivalentTo(new(int32(0))))
 								Expect(deployment.Spec.Template.Spec.Containers).To(HaveLen(1))
 								Expect(deployment.Spec.Template.Spec.Containers[0].Image).To(Equal(controllerReconciler.ClientImage))
 							})
@@ -884,7 +883,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 
 								deployment := &appsv1.Deployment{}
 								Expect(k8sClient.Get(ctx, typeNamespacedName, deployment)).To(Succeed())
-								deployment.Spec.Replicas = util.Ptr(int32(15))
+								deployment.Spec.Replicas = new(int32(15))
 								Expect(k8sClient.Update(ctx, deployment)).To(Succeed())
 
 								_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -893,7 +892,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 								Expect(err).NotTo(HaveOccurred())
 								deployment = &appsv1.Deployment{}
 								Expect(k8sClient.Get(ctx, typeNamespacedName, deployment)).To(Succeed())
-								Expect(deployment.Spec.Replicas).To(BeEquivalentTo(util.Ptr(int32(0))))
+								Expect(deployment.Spec.Replicas).To(BeEquivalentTo(new(int32(0))))
 							})
 						})
 						When("Deployment is up-to-date", func() {
@@ -920,7 +919,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						When("Privileged mode is enabled", func() {
 							It("should create deployment with privileged security context", func() {
 								Expect(k8sClient.Get(ctx, typeNamespacedName, nbroutingpeer)).To(Succeed())
-								nbroutingpeer.Spec.Privileged = util.Ptr(true)
+								nbroutingpeer.Spec.Privileged = new(true)
 								Expect(k8sClient.Update(ctx, nbroutingpeer)).To(Succeed())
 
 								_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -944,7 +943,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						When("Privileged mode is disabled", func() {
 							It("should create deployment with non-privileged security context", func() {
 								Expect(k8sClient.Get(ctx, typeNamespacedName, nbroutingpeer)).To(Succeed())
-								nbroutingpeer.Spec.Privileged = util.Ptr(false)
+								nbroutingpeer.Spec.Privileged = new(false)
 								Expect(k8sClient.Update(ctx, nbroutingpeer)).To(Succeed())
 
 								_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1004,7 +1003,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 
 								// Enable privileged mode
 								Expect(k8sClient.Get(ctx, typeNamespacedName, nbroutingpeer)).To(Succeed())
-								nbroutingpeer.Spec.Privileged = util.Ptr(true)
+								nbroutingpeer.Spec.Privileged = new(true)
 								Expect(k8sClient.Update(ctx, nbroutingpeer)).To(Succeed())
 
 								_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1022,7 +1021,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 
 							It("should update deployment security context when privileged mode is disabled", func() {
 								// First create deployment with privileged mode enabled
-								nbroutingpeer.Spec.Privileged = util.Ptr(true)
+								nbroutingpeer.Spec.Privileged = new(true)
 								Expect(k8sClient.Update(ctx, nbroutingpeer)).To(Succeed())
 
 								_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1039,7 +1038,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 
 								// Disable privileged mode
 								Expect(k8sClient.Get(ctx, typeNamespacedName, nbroutingpeer)).To(Succeed())
-								nbroutingpeer.Spec.Privileged = util.Ptr(false)
+								nbroutingpeer.Spec.Privileged = new(false)
 								Expect(k8sClient.Update(ctx, nbroutingpeer)).To(Succeed())
 
 								_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
@@ -1059,7 +1058,7 @@ var _ = Describe("NBRoutingPeer Controller", func() {
 						networkDeleted := false
 						BeforeEach(func() {
 							networkDeleted = false
-							nbroutingpeer.Status.SetupKeyID = util.Ptr("skid")
+							nbroutingpeer.Status.SetupKeyID = new("skid")
 							Expect(k8sClient.Status().Update(ctx, nbroutingpeer)).To(Succeed())
 
 							mux.HandleFunc("/api/setup-keys/skid", func(w http.ResponseWriter, r *http.Request) {

--- a/internal/controller/networkresource_controller.go
+++ b/internal/controller/networkresource_controller.go
@@ -14,7 +14,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -126,7 +125,7 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	resourceID, err := func() (string, error) {
 		netReq := api.NetworkResourceRequest{
 			Name:        string(netResource.UID),
-			Description: ptr.To(svc.Name + "/" + svc.Namespace),
+			Description: new(svc.Name + "/" + svc.Namespace),
 			Address:     svc.Spec.ClusterIP,
 			Enabled:     true,
 			Groups:      groupIDs,

--- a/internal/controller/networkrouter_controller.go
+++ b/internal/controller/networkrouter_controller.go
@@ -24,7 +24,6 @@ import (
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
 	policyv1ac "k8s.io/client-go/applyconfigurations/policy/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -166,7 +165,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			Enabled:    true,
 			Masquerade: true,
 			Metric:     9999,
-			PeerGroups: ptr.To([]string{group.Status.GroupID}),
+			PeerGroups: new([]string{group.Status.GroupID}),
 		}
 		if netRouter.Status.RoutingPeerID != "" {
 			resp, err := r.Netbird.Networks.Routers(networkID).Update(ctx, netRouter.Status.RoutingPeerID, routerReq)

--- a/internal/controller/service_controller_test.go
+++ b/internal/controller/service_controller_test.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	nbv1 "github.com/netbirdio/kubernetes-operator/api/v1"
-	"github.com/netbirdio/kubernetes-operator/internal/util"
 )
 
 var _ = Describe("Service Controller", func() {
@@ -153,7 +152,7 @@ var _ = Describe("Service Controller", func() {
 					})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(res.RequeueAfter).NotTo(BeZero())
-					nbrp.Status.NetworkID = util.Ptr(policyName)
+					nbrp.Status.NetworkID = new(policyName)
 					Expect(k8sClient.Status().Update(ctx, nbrp)).To(Succeed())
 					res, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 						NamespacedName: typeNamespacedName,
@@ -173,7 +172,7 @@ var _ = Describe("Service Controller", func() {
 					}
 					Expect(k8sClient.Create(ctx, nbrp)).To(Succeed())
 
-					nbrp.Status.NetworkID = util.Ptr(policyName)
+					nbrp.Status.NetworkID = new(policyName)
 					Expect(k8sClient.Status().Update(ctx, nbrp)).To(Succeed())
 				})
 				When("Service should be exposed", func() {
@@ -321,7 +320,7 @@ var _ = Describe("Service Controller", func() {
 				}
 				Expect(k8sClient.Create(ctx, nbrp)).To(Succeed())
 
-				nbrp.Status.NetworkID = util.Ptr(policyName)
+				nbrp.Status.NetworkID = new(policyName)
 				Expect(k8sClient.Status().Update(ctx, nbrp)).To(Succeed())
 			})
 

--- a/internal/controller/setupkey_controller.go
+++ b/internal/controller/setupkey_controller.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -126,9 +125,9 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		expiresIn = int(setupKey.Spec.Duration.Seconds())
 	}
 	setupKeyReq := api.PostApiSetupKeysJSONRequestBody{
-		AllowExtraDnsLabels: ptr.To(false),
+		AllowExtraDnsLabels: new(false),
 		AutoGroups:          autoGroupIDs,
-		Ephemeral:           ptr.To(setupKey.Spec.Ephemeral),
+		Ephemeral:           new(setupKey.Spec.Ephemeral),
 		ExpiresIn:           expiresIn,
 		Name:                setupKey.Spec.Name,
 		Type:                "reusable",

--- a/internal/util/ptr.go
+++ b/internal/util/ptr.go
@@ -1,8 +1,0 @@
-// SPDX-License-Identifier: BSD-3-Clause
-
-package util
-
-// Ptr return pointer to any value for API purposes
-func Ptr[T any, PT *T](x T) PT {
-	return &x
-}

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -12,7 +12,6 @@ require (
 	k8s.io/apimachinery v0.35.3
 	k8s.io/cli-runtime v0.35.2
 	k8s.io/client-go v0.35.3
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/kind v0.31.0
 )
 
@@ -145,6 +144,7 @@ require (
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect
 	k8s.io/kubectl v0.35.2 // indirect
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	oras.land/oras-go/v2 v2.6.0 // indirect
 	sigs.k8s.io/controller-runtime v0.23.3 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect


### PR DESCRIPTION
This change replaces all uses of pointer utils with the new `new` function which does the same job.