### PR TITLE
Add missing pdb rbac permissions (#235)

### DIFF
--- a/charts/netbird-operator/templates/rbac.yaml
+++ b/charts/netbird-operator/templates/rbac.yaml
@@ -114,6 +114,18 @@ rules:
   - create
   - delete
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
   - ""
   resources:
   - pods


### PR DESCRIPTION
RBAC was missed because we dont have full covering e2e tests yet. Yet another reason to give prio to it.

Fixes #234

(cherry picked from commit 25964a8eead639ccad40e1a0e9742bdaf676f5b3)