### PR TITLE
Update to Go 1.26.3

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -19,3 +19,13 @@ updates:
       k8s:
         patterns:
           - "k8s.io/*"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/test/e2e"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 15
+    groups:
+      gomod-e2e:
+        patterns:
+          - "*"

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netbirdio/kubernetes-operator
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/fluxcd/pkg/runtime v0.106.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/netbirdio/kubernetes-operator/test/e2e
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	github.com/go-openapi/testify/v2 v2.5.0


### PR DESCRIPTION
This change bumps the toolchain version and also enables dependabot updates for e2e tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain to a newer version for improved stability and performance
  * Enhanced automated dependency management configuration for development and testing environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/kubernetes-operator/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->