### PR TITLE
Generate release notes from PR labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    labels:
+      - "changelog/ignore"
     groups:
       github-actions:
         patterns:
@@ -15,6 +17,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    labels:
+      - "changelog/dependencies"
     groups:
       k8s:
         patterns:
@@ -25,6 +29,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 15
+    labels:
+      - "changelog/ignore"
     groups:
       gomod-e2e:
         patterns:

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,25 @@
+changelog:
+  exclude-labels:
+    - changelog/ignore
+  categories:
+    - title: Added
+      labels:
+        - changelog/added
+    - title: Changed
+      labels:
+        - changelog/changed
+    - title: Fixed
+      labels:
+        - changelog/fixed
+    - title: Deprecated
+      labels:
+        - changelog/deprecated
+    - title: Removed
+      labels:
+        - changelog/removed
+    - title: Security
+      labels:
+        - changelog/security
+    - title: Dependencies
+      labels:
+        - changelog/dependencies

--- a/.github/workflows/changelog-labels.yaml
+++ b/.github/workflows/changelog-labels.yaml
@@ -1,0 +1,20 @@
+name: changelog
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+permissions:
+  pull-requests: read
+defaults:
+  run:
+    shell: bash
+jobs:
+  labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check changelog label
+        uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe #v5.5.2
+        with:
+          mode: exactly
+          count: 1
+          use_regex: true
+          labels: "changelog/.*"


### PR DESCRIPTION
This change enables automatic release notes from labels. It also enforces a changelog label for all PRs.

Categorizing changes will make it easier for users to understand what changed in each release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Implemented automated changelog categorization and pull request label enforcement to organize release notes into semantic sections (Added, Changed, Fixed, Deprecated, Removed, Security, Dependencies) for improved clarity in future releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/kubernetes-operator/pull/265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->