### PR TITLE
Fix noisy reconcile errors

### DIFF
--- a/internal/controller/group_controller.go
+++ b/internal/controller/group_controller.go
@@ -50,6 +50,9 @@ func (r *GroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	groupID, err := func() (string, error) {
 		if group.Status.GroupID != "" {
 			groupResp, err := r.Netbird.Groups.Get(ctx, group.Status.GroupID)
+			if err != nil && !netbird.IsNotFound(err) {
+				return "", err
+			}
 			if err == nil {
 				peers := []string{}
 				for _, peer := range groupResp.Peers {

--- a/internal/controller/networkrouter_controller.go
+++ b/internal/controller/networkrouter_controller.go
@@ -126,7 +126,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	err = r.Client.Get(ctx, client.ObjectKeyFromObject(group), group)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if group.Status.GroupID == "" {
 		return ctrl.Result{}, nil
@@ -153,7 +153,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	err = r.Get(ctx, client.ObjectKeyFromObject(&setupKey), &setupKey)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if setupKey.Status.SetupKeyID == "" {
 		return ctrl.Result{}, nil
@@ -379,7 +379,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 	}
 	err = r.Client.Get(ctx, client.ObjectKeyFromObject(dep), dep)
 	if err != nil {
-		return ctrl.Result{}, err
+		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 	if dep.Status.ReadyReplicas != dep.Status.Replicas {
 		return ctrl.Result{}, nil

--- a/internal/controller/setupkey_controller.go
+++ b/internal/controller/setupkey_controller.go
@@ -53,11 +53,6 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return r.reconcileDelete(ctx, sp, setupKey)
 	}
 
-	autoGroupIDs, err := netbirdutil.GetGroupIDs(ctx, r.Client, r.Netbird, setupKey.Spec.AutoGroups, setupKey.Namespace)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-
 	controllerutil.AddFinalizer(setupKey, k8sutil.Finalizer("setupkey"))
 	err = sp.Patch(ctx, setupKey)
 	if err != nil {
@@ -65,6 +60,10 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 
 	// Check if setup key is up to date.
+	autoGroupIDs, err := netbirdutil.GetGroupIDs(ctx, r.Client, r.Netbird, setupKey.Spec.AutoGroups, setupKey.Namespace)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
 	ok, err := func() (bool, error) {
 		if setupKey.Status.SetupKeyID == "" {
 			return false, nil


### PR DESCRIPTION
Certain errors are better ignored to instead rely on the child resource to trigger a new reconcile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error handling in group resolution to prevent silent failures and ensure proper error notification
  * Improved system resilience by gracefully handling missing or unavailable Kubernetes resources without triggering reconciliation failures
  * Optimized setup key processing workflow to enhance overall system robustness and reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/netbirdio/kubernetes-operator/pull/275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->