### PR TITLE
Add codecov to Go unit tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -33,8 +33,13 @@ jobs:
         run: |
           make -B generate
           git diff --exit-code
-      - name: Running unit tests
-        run: make test
+      - name: Run unit tests
+        run: make test-unit
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 #v6.0.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: unit
   e2e:
     runs-on: ubuntu-latest
     steps:
@@ -44,5 +49,5 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go.mod
-      - name: Running e2e tests
-        run: make test-e2e
+      - name: Run e2e tests
+        run: make -B test-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ Dockerfile.cross
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Output of the go coverage tool.
+coverage.txt
 
 # Go workspace file
 go.work

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,9 @@ docs/api-reference.md: $(shell find api) docs/.crd-ref-docs.yaml
 lint:
 	@golangci-lint run ./...
 
-.PHONY: test
-test: setup-envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+.PHONY: test-unit
+test-unit: setup-envtest
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile=coverage.txt
 
 test-e2e: build-image
 	cd ./test/e2e && IMG_REF=${IMG_REF} go test ./... -v -count 1


### PR DESCRIPTION
Adds code coverage to Go unit tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Integrated automated unit test coverage reporting with Codecov integration
  * Restructured test execution to separate unit and end-to-end tests into distinct workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->