### PR TITLE
Change release workflow to trigger on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,7 @@
 name: release
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
 permissions:
   contents: read
   packages: write
@@ -20,6 +19,7 @@ jobs:
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c #v6.4.0
         with:
           go-version-file: go.mod
+          cache: false
       - name: Set up Docker
         uses: docker/setup-docker-action@0234bb73ccb40f0c430b795634f9247e2b5c2d23 #v5.2.0
         with:
@@ -39,22 +39,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Prepare versions
-        id: prep
-        run: |
-          IMG_TAG="${GITHUB_REF_NAME}"
-          if [[ "${{ github.ref_type }}" == "tag" ]]; then
-            HELM_VERSION=${GITHUB_REF_NAME#v}
-          else
-            HELM_VERSION="0.0.0-${GITHUB_REF_NAME}"
-          fi
-          echo "IMG_TAG=${IMG_TAG}" >> $GITHUB_OUTPUT
-          echo "HELM_VERSION=${HELM_VERSION}" >> $GITHUB_OUTPUT
       - name: Build and push image
         run: |
-          IMG_REF=$(make build-image-multiarch IMG_REPOSITORY=${{ github.repository_owner }}/netbird-operator IMG_TAG=${{ steps.prep.outputs.IMG_TAG }}) || exit 1
+          IMG_REF=$(make build-image-multiarch IMG_REPOSITORY=${{ github.repository_owner }}/netbird-operator IMG_TAG=${{ github.event.release.tag_name }}) || exit 1
           docker push ${IMG_REF}
       - name: Build and push Helm chart
         run: |
-          helm package --app-version ${{ steps.prep.outputs.IMG_TAG }} --version ${{ steps.prep.outputs.HELM_VERSION }} charts/netbird-operator
-          helm push netbird-operator-${{ steps.prep.outputs.HELM_VERSION }}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts
+          HELM_VERSION="${{ github.event.release.tag_name }}"
+          HELM_VERSION="${HELM_VERSION#v}"
+          helm package --app-version ${{ github.event.release.tag_name }} --version ${HELM_VERSION} charts/netbird-operator
+          helm push netbird-operator-${HELM_VERSION}.tgz oci://ghcr.io/${{ github.repository_owner }}/helm-charts


### PR DESCRIPTION
This will make it easier to maintainers to cut a release without having to manually create tags in the repo.