### PR TITLE
Pass management URL to ClusterProxy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -313,8 +313,9 @@ func main() {
 			os.Exit(1)
 		}
 		if err := (&controller.ClusterProxyReconciler{
-			Client: mgr.GetClient(),
-			ApiKey: netbirdAPIKey,
+			Client:        mgr.GetClient(),
+			ApiKey:        netbirdAPIKey,
+			ManagementURL: managementURL,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "Failed to create controller", "controller", "ClusterProxy")
 			os.Exit(1)

--- a/internal/controller/clusterproxy_controller.go
+++ b/internal/controller/clusterproxy_controller.go
@@ -29,7 +29,8 @@ import (
 type ClusterProxyReconciler struct {
 	client.Client
 
-	ApiKey string
+	ApiKey        string
+	ManagementURL string
 }
 
 // +kubebuilder:rbac:groups=netbird.io,resources=clusterproxies,verbs=get;list;watch;create;update;patch;delete
@@ -124,6 +125,8 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					clusterProxy.Spec.ClusterName,
 					"--kubernetes-api-server",
 					clusterProxy.Spec.APIServer,
+					"--management-url",
+					r.ManagementURL,
 				).
 				WithEnv(
 					corev1ac.EnvVar().


### PR DESCRIPTION
The proxy container defaults `--management-url` to `https://api.netbird.io`, so on self-hosted NetBird the proxy talks to SaaS and rejects the setup key as invalid.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a management URL for the cluster proxy service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->