### PR TITLE
Add codecov for e2e tests

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -51,3 +51,11 @@ jobs:
           go-version-file: go.mod
       - name: Run e2e tests
         run: make -B test-e2e
+      - run: tree ./test/e2e/_artifacts
+      - name: Format coverage data
+        run: go tool covdata textfmt -i=$(ls -d ./test/e2e/_artifacts/*/ | tr '\n' ',' | sed 's/,$//') -o=coverage.txt
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f #v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: e2e

--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,14 @@ test-unit: setup-envtest
 	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test -v ./... -coverprofile=coverage.txt
 
 test-e2e: build-image
-	cd ./test/e2e && IMG_REF=${IMG_REF} go test ./... -v -count 1
+	cd ./test/e2e && IMG_REF=${IMG_REF} go test ./... -v -count 1 -artifacts $(pwd)
 
 .PHONY: build
 build: generate bin/linux-$(shell go env GOARCH)/netbird-operator
 
 bin/linux-%/netbird-operator: $(shell find api cmd internal pkg) go.mod go.sum
-	@CGO_ENABLED=0 GOOS=linux GOARCH=$* go build -ldflags="-w -s" -trimpath -o $@ cmd/main.go
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$* go build -cover -o $@ cmd/main.go
+	# @CGO_ENABLED=0 GOOS=linux GOARCH=$* go build -cover -ldflags="-w -s" -trimpath -o $@ cmd/main.go
 
 .PHONY: build-image
 build-image: build

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,3 +1,5 @@
+codecov:
+  notify: 2
 ignore:
   - api
   - pkg/applyconfigurations

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -69,6 +69,12 @@ func TestE2E(t *testing.T) {
 				Nodes: []kindv1alpha1.Node{
 					{
 						Role: kindv1alpha1.ControlPlaneRole,
+						ExtraMounts: []kindv1alpha1.Mount{
+							{
+								HostPath:      t.ArtifactDir(),
+								ContainerPath: "/coverage",
+							},
+						},
 					},
 				},
 			}
@@ -113,6 +119,9 @@ func TestE2E(t *testing.T) {
 				}
 				return nil
 			}, 30*time.Second, 1*time.Second)
+
+			err = kindNodes[0].CommandContext(t.Context(), "chmod", "o+rwx", "/coverage").Run()
+			require.NoError(t, err)
 
 			t.Log("Importing image", imgRef)
 			f, err := os.Open(imgPath)
@@ -188,6 +197,27 @@ func TestE2E(t *testing.T) {
 				_, err := upgrade.RunWithContext(t.Context(), "netbird-operator", charter, vals)
 				require.NoError(t, err)
 			}
+
+			dep, err := k8sClient.AppsV1().Deployments(netbirdNamespace).Get(t.Context(), "netbird-operator", metav1.GetOptions{})
+			require.NoError(t, err)
+			coverVolume := corev1.Volume{
+				Name: "coverage",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/coverage",
+						Type: new(corev1.HostPathDirectory),
+					},
+				},
+			}
+			dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, coverVolume)
+			coverVolumeMount := corev1.VolumeMount{
+				Name:      "coverage",
+				MountPath: "/coverage",
+			}
+			dep.Spec.Template.Spec.Containers[0].VolumeMounts = append(dep.Spec.Template.Spec.Containers[0].VolumeMounts, coverVolumeMount)
+			dep.Spec.Template.Spec.Containers[0].Env = append(dep.Spec.Template.Spec.Containers[0].Env, corev1.EnvVar{Name: "GOCOVERDIR", Value: "/coverage"})
+			_, err = k8sClient.AppsV1().Deployments(netbirdNamespace).Update(t.Context(), dep, metav1.UpdateOptions{})
+			require.NoError(t, err)
 		})
 	}
 }


### PR DESCRIPTION
This makes things more visible in codecov for what is actually being tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end pipeline to collect, format and upload e2e coverage reports to the coverage service.
  * Adjusted test runtime to share artifacts with the test cluster so coverage output is persisted and retrievable.
  * Updated build and CI recipes to produce Linux binaries with coverage instrumentation and improved artifact handling.
  * Enabled coverage notification settings in CI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->