### PR TITLE
Force ownership on apply to resolve conflicts with manual edits

### DIFF
--- a/internal/controller/clusterproxy_controller.go
+++ b/internal/controller/clusterproxy_controller.go
@@ -66,7 +66,7 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				WithEphemeral(true).
 				WithAllowExtraDnsLabels(true),
 		)
-	err = r.Client.Apply(ctx, setupKeyAC)
+	err = r.Client.Apply(ctx, setupKeyAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -88,7 +88,7 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	secretAC := corev1ac.Secret(fmt.Sprintf("clusterproxy-%s", req.Name), req.Namespace).
 		WithOwnerReferences(ownerRef).
 		WithStringData(map[string]string{"api-key": r.ApiKey})
-	err = r.Client.Apply(ctx, secretAC)
+	err = r.Client.Apply(ctx, secretAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -170,7 +170,7 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		WithOwnerReferences(ownerRef).
 		WithLabels(selectorLabels).
 		WithSpec(appsv1ac.DeploymentSpec().WithReplicas(1).WithSelector(metav1ac.LabelSelector().WithMatchLabels(selectorLabels)).WithTemplate(podTemplateSpecAC))
-	err = r.Client.Apply(ctx, depAC)
+	err = r.Client.Apply(ctx, depAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -105,7 +105,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 						WithNetworkRouterRef(nbv1alpha1ac.CrossNamespaceReference().WithName(netRouter.Name).WithNamespace(netRouter.Namespace)).
 						WithServiceRef(corev1.LocalObjectReference{Name: svc.Name}),
 				)
-			err = r.Client.Apply(ctx, netResourceAC)
+			err = r.Client.Apply(ctx, netResourceAC, client.ForceOwnership)
 			if err != nil {
 				return ctrl.Result{}, err
 			}

--- a/internal/controller/networkrouter_controller.go
+++ b/internal/controller/networkrouter_controller.go
@@ -114,7 +114,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			nbv1alpha1ac.GroupSpec().
 				WithName(fmt.Sprintf("networkrouter-%s", uniqueSuffix)),
 		)
-	err = r.Client.Apply(ctx, groupAC)
+	err = r.Client.Apply(ctx, groupAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -141,7 +141,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				WithEphemeral(true).
 				WithAutoGroups(nbv1alpha1ac.GroupReference().WithID(group.Status.GroupID)),
 		)
-	err = r.Client.Apply(ctx, setupKeyAC)
+	err = r.Client.Apply(ctx, setupKeyAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -338,7 +338,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		WithLabels(workloadLabels).
 		WithAnnotations(workloadAnnotations).
 		WithSpec(appsv1ac.DeploymentSpec().WithReplicas(replicas).WithSelector(metav1ac.LabelSelector().WithMatchLabels(selectorLabels)).WithTemplate(podTemplateSpecAC))
-	err = r.Client.Apply(ctx, depAC)
+	err = r.Client.Apply(ctx, depAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}
@@ -354,7 +354,7 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 					WithMatchLabels(selectorLabels),
 				),
 			)
-		err = r.Client.Apply(ctx, pdbAC)
+		err = r.Client.Apply(ctx, pdbAC, client.ForceOwnership)
 		if err != nil {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/setupkey_controller.go
+++ b/internal/controller/setupkey_controller.go
@@ -149,7 +149,7 @@ func (r *SetupKeyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	secret := corev1ac.Secret(setupKey.SecretName(), req.Namespace).
 		WithStringData(data).
 		WithOwnerReferences(owner)
-	err = r.Client.Apply(ctx, secret)
+	err = r.Client.Apply(ctx, secret, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/internal/controller/tcproute_controller.go
+++ b/internal/controller/tcproute_controller.go
@@ -95,7 +95,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 						WithNetworkRouterRef(nbv1alpha1ac.CrossNamespaceReference().WithName(netRouter.Name).WithNamespace(netRouter.Namespace)).
 						WithServiceRef(corev1.LocalObjectReference{Name: svc.Name}),
 				)
-			err = r.Client.Apply(ctx, netResourceAC)
+			err = r.Client.Apply(ctx, netResourceAC, client.ForceOwnership)
 			if err != nil {
 				return ctrl.Result{}, err
 			}


### PR DESCRIPTION
If not set the apply will error if a resource has been manually edited. This changes all apply calls to use force ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed resource ownership handling across multiple controllers to ensure proper claim and management of Kubernetes resources during deployment and reconciliation operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->