### PR TITLE
Update version of api proxy

### DIFF
--- a/internal/controller/clusterproxy_controller.go
+++ b/internal/controller/clusterproxy_controller.go
@@ -13,6 +13,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	appsv1ac "k8s.io/client-go/applyconfigurations/apps/v1"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1ac "k8s.io/client-go/applyconfigurations/meta/v1"
@@ -128,6 +129,9 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 					"--management-url",
 					r.ManagementURL,
 				).
+				WithReadinessProbe(
+					corev1ac.Probe().WithHTTPGet(corev1ac.HTTPGetAction().WithPath("/readyz").WithPort(intstr.FromInt(8081))),
+				).
 				WithEnv(
 					corev1ac.EnvVar().
 						WithName("POD_NAME").
@@ -169,7 +173,7 @@ func (r *ClusterProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	depAC := appsv1ac.Deployment(fmt.Sprintf("clusterproxy-%s", req.Name), req.Namespace).
 		WithOwnerReferences(ownerRef).
 		WithLabels(selectorLabels).
-		WithSpec(appsv1ac.DeploymentSpec().WithReplicas(1).WithSelector(metav1ac.LabelSelector().WithMatchLabels(selectorLabels)).WithTemplate(podTemplateSpecAC))
+		WithSpec(appsv1ac.DeploymentSpec().WithReplicas(3).WithSelector(metav1ac.LabelSelector().WithMatchLabels(selectorLabels)).WithTemplate(podTemplateSpecAC))
 	err = r.Client.Apply(ctx, depAC, client.ForceOwnership)
 	if err != nil {
 		return ctrl.Result{}, err

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	NetbirdClientImage = "ghcr.io/netbirdio/netbird:0.72.4@sha256:6c6c20baffae4a3ec50f29ec9361608a420625185505e8cd6f0c44d71c5d4798"
-	KubeApiProxyImage  = "ghcr.io/netbirdio/netbird-kubeapi-proxy:v0.0.1@sha256:aa5bbdfc2eca51438f3d50ed4441d61388e9a8d2d5dc886cc4988dacd36ad648"
+	KubeApiProxyImage  = "ghcr.io/netbirdio/netbird-kubeapi-proxy:v0.0.4@sha256:bffa4f093abc19b4934ae37657bac76fa3b390cbd39aadac987634215eb750f5"
 )
 
 func BuildVersion() string {


### PR DESCRIPTION
This change updates the api proxy version and configures a readiness probe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced cluster proxy health monitoring with readiness checks.
  * Increased cluster proxy replicas to 3 for improved availability and resilience.
  * Updated kubeapi-proxy to the latest version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->