### PR TITLE
feat(httproute): add support for annotation to control service setting

### DIFF
--- a/internal/controller/httproute_controller.go
+++ b/internal/controller/httproute_controller.go
@@ -153,6 +153,15 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 				Targets:          &targets,
 			}
 
+			// Overlay optional per-service config (private, access groups,
+			// CrowdSec, IP/geo restrictions, header behaviour) from the
+			// HTTPRoute's annotations. Without this the fields above are the
+			// only ones ever sent, so anything set in the dashboard is reset
+			// on the next reconcile.
+			if err := applyServiceAnnotations(hr, &proxyReq); err != nil {
+				return ctrl.Result{}, err
+			}
+
 			err := func() error {
 				for _, proxyService := range proxyServices {
 					if proxyService.Domain != string(hostname) {

--- a/internal/controller/httproute_serviceconfig.go
+++ b/internal/controller/httproute_serviceconfig.go
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+
+	"github.com/netbirdio/kubernetes-operator/internal/util"
+)
+
+// Annotations on an HTTPRoute that tune the NetBird reverse-proxy service the
+// operator creates for it. They map onto fields of api.ServiceRequest that the
+// reconciler would otherwise leave unset -- and therefore reset to their zero
+// value on every reconcile, clobbering anything configured in the dashboard.
+const (
+	// servicePrivateAnnotation marks the service NetBird-only (mode=http).
+	// Inbound peers authenticate via their tunnel identity; an ACL policy is
+	// auto-generated from the access groups. Boolean.
+	servicePrivateAnnotation = "netbird.io/private"
+	// serviceAccessGroupsAnnotation is the comma-separated list of NetBird
+	// group IDs whose peers may reach a private service. Required when
+	// private=true, ignored otherwise.
+	serviceAccessGroupsAnnotation = "netbird.io/access-groups"
+	// serviceCrowdsecModeAnnotation sets CrowdSec IP-reputation handling:
+	// off | observe | enforce. Only effective when the proxy cluster supports
+	// CrowdSec.
+	serviceCrowdsecModeAnnotation = "netbird.io/crowdsec-mode"
+	// serviceAllowedCidrsAnnotation / serviceBlockedCidrsAnnotation are
+	// comma-separated CIDR allow/block lists (allow evaluated first).
+	serviceAllowedCidrsAnnotation = "netbird.io/allowed-cidrs"
+	serviceBlockedCidrsAnnotation = "netbird.io/blocked-cidrs"
+	// serviceAllowedCountriesAnnotation / serviceBlockedCountriesAnnotation are
+	// comma-separated ISO 3166-1 alpha-2 country-code allow/block lists.
+	serviceAllowedCountriesAnnotation = "netbird.io/allowed-countries"
+	serviceBlockedCountriesAnnotation = "netbird.io/blocked-countries"
+	// servicePassHostHeaderAnnotation / serviceRewriteRedirectsAnnotation
+	// override the proxy header behaviour (both default to false). Boolean.
+	servicePassHostHeaderAnnotation   = "netbird.io/pass-host-header"
+	serviceRewriteRedirectsAnnotation = "netbird.io/rewrite-redirects"
+)
+
+// applyServiceAnnotations overlays the optional configuration carried on an
+// HTTPRoute's annotations onto a freshly built api.ServiceRequest. Absent
+// annotations leave the corresponding field untouched, preserving the
+// reconciler's defaults. An invalid value is returned as an error so the
+// reconcile surfaces it instead of silently dropping the setting.
+func applyServiceAnnotations(hr *gwv1.HTTPRoute, req *api.ServiceRequest) error {
+	a := hr.GetAnnotations()
+	if a == nil {
+		return nil
+	}
+
+	for ann, target := range map[string]**bool{
+		servicePrivateAnnotation:          &req.Private,
+		servicePassHostHeaderAnnotation:   &req.PassHostHeader,
+		serviceRewriteRedirectsAnnotation: &req.RewriteRedirects,
+	} {
+		v, ok := a[ann]
+		if !ok {
+			continue
+		}
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return fmt.Errorf("annotation %s: %w", ann, err)
+		}
+		*target = new(b)
+	}
+
+	if v, ok := a[serviceAccessGroupsAnnotation]; ok {
+		groups := util.SplitTrim(v, ",")
+		req.AccessGroups = &groups
+	}
+
+	ar, err := buildAccessRestrictions(a)
+	if err != nil {
+		return err
+	}
+	if ar != nil {
+		req.AccessRestrictions = ar
+	}
+
+	return nil
+}
+
+// buildAccessRestrictions assembles an api.AccessRestrictions from the CrowdSec,
+// CIDR and country annotations, or returns nil when none of them are present.
+func buildAccessRestrictions(a map[string]string) (*api.AccessRestrictions, error) {
+	var (
+		ar  api.AccessRestrictions
+		set bool
+	)
+
+	if v, ok := a[serviceCrowdsecModeAnnotation]; ok {
+		mode := api.AccessRestrictionsCrowdsecMode(v)
+		if !mode.Valid() {
+			return nil, fmt.Errorf("annotation %s: invalid crowdsec mode %q (want off|observe|enforce)", serviceCrowdsecModeAnnotation, v)
+		}
+		ar.CrowdsecMode = new(mode)
+		set = true
+	}
+
+	for ann, target := range map[string]**[]string{
+		serviceAllowedCidrsAnnotation:     &ar.AllowedCidrs,
+		serviceBlockedCidrsAnnotation:     &ar.BlockedCidrs,
+		serviceAllowedCountriesAnnotation: &ar.AllowedCountries,
+		serviceBlockedCountriesAnnotation: &ar.BlockedCountries,
+	} {
+		if v, ok := a[ann]; ok {
+			list := util.SplitTrim(v, ",")
+			*target = &list
+			set = true
+		}
+	}
+
+	if !set {
+		return nil, nil
+	}
+	return &ar, nil
+}

--- a/internal/controller/httproute_serviceconfig_test.go
+++ b/internal/controller/httproute_serviceconfig_test.go
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/netbirdio/netbird/shared/management/http/api"
+)
+
+func routeWith(annotations map[string]string) *gwv1.HTTPRoute {
+	return &gwv1.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+}
+
+func TestApplyServiceAnnotations(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no annotations leaves request untouched", func(t *testing.T) {
+		t.Parallel()
+		req := api.ServiceRequest{Domain: "x", PassHostHeader: new(false)}
+		require.NoError(t, applyServiceAnnotations(routeWith(nil), &req))
+		require.Nil(t, req.Private)
+		require.Nil(t, req.AccessGroups)
+		require.Nil(t, req.AccessRestrictions)
+		require.Equal(t, false, *req.PassHostHeader)
+	})
+
+	t.Run("private service with access groups", func(t *testing.T) {
+		t.Parallel()
+		req := api.ServiceRequest{}
+		err := applyServiceAnnotations(routeWith(map[string]string{
+			servicePrivateAnnotation:      "true",
+			serviceAccessGroupsAnnotation: "grp-a, grp-b ,grp-c",
+		}), &req)
+		require.NoError(t, err)
+		require.NotNil(t, req.Private)
+		require.True(t, *req.Private)
+		require.NotNil(t, req.AccessGroups)
+		require.Equal(t, []string{"grp-a", "grp-b", "grp-c"}, *req.AccessGroups)
+	})
+
+	t.Run("crowdsec and geo restrictions", func(t *testing.T) {
+		t.Parallel()
+		req := api.ServiceRequest{}
+		err := applyServiceAnnotations(routeWith(map[string]string{
+			serviceCrowdsecModeAnnotation:     "enforce",
+			serviceBlockedCountriesAnnotation: "RU,KP",
+			serviceAllowedCidrsAnnotation:     "10.0.0.0/8",
+		}), &req)
+		require.NoError(t, err)
+		require.NotNil(t, req.AccessRestrictions)
+		require.NotNil(t, req.AccessRestrictions.CrowdsecMode)
+		require.Equal(t, api.AccessRestrictionsCrowdsecModeEnforce, *req.AccessRestrictions.CrowdsecMode)
+		require.Equal(t, []string{"RU", "KP"}, *req.AccessRestrictions.BlockedCountries)
+		require.Equal(t, []string{"10.0.0.0/8"}, *req.AccessRestrictions.AllowedCidrs)
+		require.Nil(t, req.AccessRestrictions.AllowedCountries)
+	})
+
+	t.Run("invalid crowdsec mode errors", func(t *testing.T) {
+		t.Parallel()
+		req := api.ServiceRequest{}
+		err := applyServiceAnnotations(routeWith(map[string]string{
+			serviceCrowdsecModeAnnotation: "panic",
+		}), &req)
+		require.Error(t, err)
+	})
+
+	t.Run("invalid bool errors", func(t *testing.T) {
+		t.Parallel()
+		req := api.ServiceRequest{}
+		err := applyServiceAnnotations(routeWith(map[string]string{
+			servicePrivateAnnotation: "yesplease",
+		}), &req)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Adding annotation support to httproute to configure reverse proxy:
- setting private service 
- setting crowdsec
- etc. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * HTTPRoute annotations now enable per-service reverse-proxy configuration, allowing users to set privacy flags, control header forwarding behavior, manage access groups, and define CIDR/country-based access restrictions directly on routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->