### PR TITLE
Use kind version specific node images for e2e tests

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -61,7 +61,7 @@ func TestE2E(t *testing.T) {
 	require.NoError(t, err)
 
 	kubernetesVersions := []string{
-		"1.36.0",
+		"v0.32.0-v1.36.2",
 	}
 	for _, kubernetesVersion := range kubernetesVersions {
 		t.Run(kubernetesVersion, func(t *testing.T) {


### PR DESCRIPTION
Kind node images are not guaranteed to be compatible between Kind versions. So we are using specific images instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to support additional Kubernetes cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->