### PR TITLE
Ignore Netbird dependency in e2e test dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -31,6 +31,8 @@ updates:
     open-pull-requests-limit: 15
     labels:
       - "changelog/ignore"
+    ignore:
+      - dependency-name: "github.com/netbirdio/netbird"
     groups:
       gomod-e2e:
         patterns:


### PR DESCRIPTION
We dont want to run different Netbird versions in e2e tests and the actual client. So we only allow updates in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update settings to skip a specific Go module from automated update pull requests, reducing unnecessary maintenance noise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->