### PR TITLE
Bump Go to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/netbirdio/kubernetes-operator
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 require (
 	github.com/fluxcd/pkg/runtime v0.110.0

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -2,7 +2,7 @@ module github.com/netbirdio/kubernetes-operator/test/e2e
 
 go 1.26.0
 
-toolchain go1.26.3
+toolchain go1.26.5
 
 replace github.com/netbirdio/kubernetes-operator => ../../
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required Go toolchain version to 1.26.5.
  * Applied the same toolchain update to end-to-end testing components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->