### PR TITLE
Fix egress example and RBAC typo

### DIFF
--- a/charts/netbird-operator/templates/rbac.yaml
+++ b/charts/netbird-operator/templates/rbac.yaml
@@ -60,7 +60,7 @@ rules:
   - groups/status
   - networkrouters/status
   - networkresources/status
-  - networkregresses/status
+  - networkegresses/status
   - sidecarprofiles/status
   - clusterproxies/status
   verbs:

--- a/examples/network/networkegress.yaml
+++ b/examples/network/networkegress.yaml
@@ -8,8 +8,8 @@ spec:
     name: prod
     namespace: netbird
   target:
-    ip:
-      address: 10.96.92.40
+    fqdn:
+      hostname: nginx.default.prod.company.internal
   ports:
     - name: http
       port: 80


### PR DESCRIPTION
Found a typo in rbac and issue with example while preparing walk-through docs.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/kubernetes-operator/pr/374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786871474&installation_id=146802194&pr_number=374&repository=netbirdio%2Fkubernetes-operator&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fkubernetes-operator%2Fpull%2F374&signature=050e666d4eacb869624c2045bdedd563bc789a733a0882abb61ae5c880528c3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected permissions for accessing NetworkEgress status resources.
* **Examples**
  * Updated the NetworkEgress example to target a service by fully qualified domain name instead of a static IP address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->