### PR TITLE
Prune egress endpoint slices by desired state

### DIFF
--- a/internal/controller/forwarderservice_controller.go
+++ b/internal/controller/forwarderservice_controller.go
@@ -9,14 +9,11 @@ import (
 	"maps"
 	"net/netip"
 	"strings"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	corev1ac "k8s.io/client-go/applyconfigurations/core/v1"
 	discoveryv1ac "k8s.io/client-go/applyconfigurations/discovery/v1"
@@ -37,7 +34,6 @@ const (
 	ForwarderRouterNameLabel   = "netbird.io/forwarder-router-name"
 	EgressRouterNameLabel      = "netbird.io/egress-router-name"
 	EgressRouterNamespaceLabel = "netbird.io/egress-router-namespace"
-	LastUpdatedLabel           = "netbird.io/last-updated"
 )
 
 // ForwarderServiceReconciler reconciles a EndpointSlice object
@@ -96,7 +92,7 @@ func (r *ForwarderServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Copy router endpoint slices to egress services.
-	lastUpdated := fmt.Sprintf("%d", time.Now().Unix())
+	desired := map[types.NamespacedName]struct{}{}
 
 	for _, egressSvc := range egressSvcList.Items {
 		netEgress := &nbv1alpha1.NetworkEgress{
@@ -140,15 +136,15 @@ func (r *ForwarderServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		for _, endpointSlice := range endpointSliceList.Items {
 			nameSuffx := strings.TrimPrefix(endpointSlice.Name, endpointSlice.GenerateName)
 
-			labels := map[string]string{
-				discoveryv1.LabelServiceName: egressSvc.Name,
-				discoveryv1.LabelManagedBy:   "netbird-operator.netbird.io",
-				LastUpdatedLabel:             lastUpdated,
-			}
+			labels := make(map[string]string, len(egressSvc.Labels)+2)
 			maps.Copy(labels, egressSvc.Labels)
+			labels[discoveryv1.LabelServiceName] = egressSvc.Name
+			labels[discoveryv1.LabelManagedBy] = "netbird-operator.netbird.io"
 
+			name := fmt.Sprintf("%s-%s", egressSvc.Name, nameSuffx)
+			desired[types.NamespacedName{Namespace: egressSvc.Namespace, Name: name}] = struct{}{}
 			endpointACs := toEndpointApplyConfigurations(endpointSlice.Endpoints)
-			endpointSliceAC := discoveryv1ac.EndpointSlice(fmt.Sprintf("%s-%s", egressSvc.Name, nameSuffx), egressSvc.Namespace).
+			endpointSliceAC := discoveryv1ac.EndpointSlice(name, egressSvc.Namespace).
 				WithLabels(labels).
 				WithOwnerReferences(egressSvcOwnerRef).
 				WithAddressType(endpointSlice.AddressType).
@@ -175,29 +171,14 @@ func (r *ForwarderServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	// Cleanup old endpoint slices.
-	updateReq, err := labels.NewRequirement(LastUpdatedLabel, selection.NotEquals, []string{lastUpdated})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	egressNameReq, err := labels.NewRequirement(EgressRouterNameLabel, selection.Equals, []string{routerName})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	egressNamespaceReq, err := labels.NewRequirement(EgressRouterNamespaceLabel, selection.Equals, []string{req.Namespace})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	sourceReq, err := labels.NewRequirement(discoveryv1.LabelServiceName, selection.NotEquals, []string{svc.Name})
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	deleteSelector := labels.NewSelector().Add(*updateReq).Add(*egressNameReq).Add(*egressNamespaceReq).Add(*sourceReq)
-
-	err = r.Client.List(ctx, endpointSliceList, client.MatchingLabelsSelector{Selector: deleteSelector})
+	err = r.Client.List(ctx, endpointSliceList, &client.MatchingLabels{EgressRouterNameLabel: routerName, EgressRouterNamespaceLabel: req.Namespace})
 	if err != nil {
 		return ctrl.Result{}, err
 	}
 	for _, item := range endpointSliceList.Items {
+		if _, ok := desired[client.ObjectKeyFromObject(&item)]; ok {
+			continue
+		}
 		if err := r.Client.Delete(ctx, &item); err != nil && !kerrors.IsNotFound(err) {
 			return ctrl.Result{}, err
 		}

--- a/internal/controller/forwarderservice_controller_test.go
+++ b/internal/controller/forwarderservice_controller_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+)
+
+var _ = Describe("ForwarderService Controller", func() {
+	Context("When reconciling", func() {
+		ctx := context.Background()
+
+		const routerName = "fwd-router"
+		var namespace string
+		var fwdSvcNN client.ObjectKey
+
+		var netEgressRec *NetworkEgressReconciler
+		var forwarderRec *ForwarderServiceReconciler
+
+		BeforeEach(func() {
+			namespace = fmt.Sprintf("forwarder-service-%d", time.Now().UnixNano())
+			fwdSvcNN = client.ObjectKey{
+				Name:      fmt.Sprintf("networkrouter-%s-forwarder", routerName),
+				Namespace: namespace,
+			}
+			netEgressRec = &NetworkEgressReconciler{
+				Client: k8sClient,
+			}
+			forwarderRec = &ForwarderServiceReconciler{
+				Client: k8sClient,
+			}
+
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+			netRouter := &nbv1alpha1.NetworkRouter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      routerName,
+					Namespace: namespace,
+				},
+				Spec: nbv1alpha1.NetworkRouterSpec{
+					DNSZoneRef: nbv1alpha1.DNSZoneReference{
+						Name: "foo.bar",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, netRouter)).To(Succeed())
+
+			fwdSvc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fwdSvcNN.Name,
+					Namespace: namespace,
+					Labels: map[string]string{
+						ForwarderRouterNameLabel: routerName,
+					},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{Name: "http", Port: 80},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, fwdSvc)).To(Succeed())
+
+			fwdSlice := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:         fwdSvcNN.Name + "-abc12",
+					GenerateName: fwdSvcNN.Name + "-",
+					Namespace:    namespace,
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: fwdSvcNN.Name,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{Addresses: []string{"10.0.0.1"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, fwdSlice)).To(Succeed())
+
+			netEgress := &nbv1alpha1.NetworkEgress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "egress",
+					Namespace: namespace,
+				},
+				Spec: nbv1alpha1.NetworkEgressSpec{
+					NetworkRouterRef: nbv1alpha1.CrossNamespaceReference{
+						Name:      routerName,
+						Namespace: namespace,
+					},
+					Target: nbv1alpha1.NetworkEgressTarget{
+						FQDN: &nbv1alpha1.NetworkEgressFQDNTarget{
+							Hostname: "example.com",
+						},
+					},
+					Ports: []nbv1alpha1.NetworkEgressPort{
+						{Name: "http", Port: 80},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, netEgress)).To(Succeed())
+			_, err := netEgressRec.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(netEgress)})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			ns := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+				},
+			}
+			Expect(k8sClient.Delete(ctx, ns)).To(Succeed())
+		})
+
+		It("does not modify derived objects when nothing changed", func() {
+			_, err := forwarderRec.Reconcile(ctx, reconcile.Request{NamespacedName: fwdSvcNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, fwdSvcNN, cm)).To(Succeed())
+			sliceList := &discoveryv1.EndpointSliceList{}
+			Expect(k8sClient.List(ctx, sliceList, client.InNamespace(namespace), client.MatchingLabels{EgressRouterNameLabel: routerName})).To(Succeed())
+			Expect(sliceList.Items).NotTo(BeEmpty())
+			versions := map[string]string{cm.Name: cm.ResourceVersion}
+			for _, item := range sliceList.Items {
+				versions[item.Name] = item.ResourceVersion
+			}
+
+			time.Sleep(1100 * time.Millisecond)
+			_, err = forwarderRec.Reconcile(ctx, reconcile.Request{NamespacedName: fwdSvcNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(k8sClient.Get(ctx, fwdSvcNN, cm)).To(Succeed())
+			Expect(cm.ResourceVersion).To(Equal(versions[cm.Name]))
+			Expect(k8sClient.List(ctx, sliceList, client.InNamespace(namespace), client.MatchingLabels{EgressRouterNameLabel: routerName})).To(Succeed())
+			for _, item := range sliceList.Items {
+				Expect(item.ResourceVersion).To(Equal(versions[item.Name]), item.Name)
+			}
+		})
+
+		It("prunes endpoint slices that are no longer desired", func() {
+			stray := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stray",
+					Namespace: namespace,
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: "gone",
+						EgressRouterNameLabel:        routerName,
+						EgressRouterNamespaceLabel:   namespace,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{Addresses: []string{"10.0.0.2"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, stray)).To(Succeed())
+
+			_, err := forwarderRec.Reconcile(ctx, reconcile.Request{NamespacedName: fwdSvcNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(stray), stray)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("prunes same-named endpoint slices in other namespaces", func() {
+			otherNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace + "-other"},
+			}
+			Expect(k8sClient.Create(ctx, otherNamespace)).To(Succeed())
+			DeferCleanup(func() {
+				Expect(k8sClient.Delete(ctx, otherNamespace)).To(Succeed())
+			})
+
+			stray := &discoveryv1.EndpointSlice{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "egress-abc12",
+					Namespace: otherNamespace.Name,
+					Labels: map[string]string{
+						discoveryv1.LabelServiceName: "egress",
+						EgressRouterNameLabel:        routerName,
+						EgressRouterNamespaceLabel:   namespace,
+					},
+				},
+				AddressType: discoveryv1.AddressTypeIPv4,
+				Endpoints: []discoveryv1.Endpoint{
+					{Addresses: []string{"10.0.0.2"}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, stray)).To(Succeed())
+
+			_, err := forwarderRec.Reconcile(ctx, reconcile.Request{NamespacedName: fwdSvcNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(stray), stray)
+			Expect(kerrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("preserves system labels on derived endpoint slices", func() {
+			egressSvc := &corev1.Service{}
+			key := client.ObjectKey{Name: "egress", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, key, egressSvc)).To(Succeed())
+			egressSvc.Labels[discoveryv1.LabelServiceName] = "wrong"
+			egressSvc.Labels[discoveryv1.LabelManagedBy] = "wrong"
+			egressSvc.Labels["example.com/custom"] = "value"
+			Expect(k8sClient.Update(ctx, egressSvc)).To(Succeed())
+
+			_, err := forwarderRec.Reconcile(ctx, reconcile.Request{NamespacedName: fwdSvcNN})
+			Expect(err).NotTo(HaveOccurred())
+
+			slice := &discoveryv1.EndpointSlice{}
+			key = client.ObjectKey{Name: "egress-abc12", Namespace: namespace}
+			Expect(k8sClient.Get(ctx, key, slice)).To(Succeed())
+			Expect(slice.Labels).To(HaveKeyWithValue(discoveryv1.LabelServiceName, "egress"))
+			Expect(slice.Labels).To(HaveKeyWithValue(discoveryv1.LabelManagedBy, "netbird-operator.netbird.io"))
+			Expect(slice.Labels).To(HaveKeyWithValue("example.com/custom", "value"))
+		})
+	})
+})


### PR DESCRIPTION
Creating a single NetworkEgress (v0.8.0, GKE) produced 689 forwarder-ConfigMap rewrites in ~12s: each reconcile stamps watched EndpointSlices with a time.Now() label (used for stale-slice cleanup), so every pass mutates its own watch sources and re-triggers itself. Combined with issue described in https://github.com/netbirdio/kube-egress-forwarder/pull/5, this left egress ports dead until a router restart.

Fixed by pruning slices against the desired set instead; the label and selector machinery go away. Same scenario now produces one event, and remove/re-add converges without restarts. Includes an envtest that fails on main plus a pruning regression test. Full ConfigMap determinism also needs https://github.com/netbirdio/kube-egress-forwarder/pull/5 first.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved endpoint resource cleanup during reconciliation.
  * Prevented deletion of valid endpoint resources based solely on their age.
  * Removed obsolete endpoint resources that no longer match the current service configuration.

* **Tests**
  * Added coverage confirming unchanged resources are not unnecessarily modified.
  * Added coverage verifying stale endpoint resources are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->