### PR TITLE
Update kube forwarder version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/go-openapi/testify/v2 v2.6.0
 	github.com/google/uuid v1.6.0
-	github.com/netbirdio/kube-egress-forwarder v0.0.2
+	github.com/netbirdio/kube-egress-forwarder v0.0.3
 	github.com/netbirdio/netbird v0.74.7
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1

--- a/go.sum
+++ b/go.sum
@@ -340,8 +340,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/netbirdio/dex v0.244.1-0.20260512110716-8d70ad8647c1 h1:4TaYr9O4xX0D2kszeOLclTiCbA3eHq3xWV+9ILJbIYs=
 github.com/netbirdio/dex v0.244.1-0.20260512110716-8d70ad8647c1/go.mod h1:IHH+H8vK2GfqtIt5u/5OdPh18yk0oDHuj2vz5+Goetg=
-github.com/netbirdio/kube-egress-forwarder v0.0.2 h1:jUlgA8lSDKyqn9tUdRFtEadXdDCFA63ZFPenQrMGv7E=
-github.com/netbirdio/kube-egress-forwarder v0.0.2/go.mod h1:Lyt9k/93DTWaeOiGQWM63WtQNj/9NnMTR/PivDgWXXE=
+github.com/netbirdio/kube-egress-forwarder v0.0.3 h1:6lkQ0opW+kef0w1HJNd7YDYvh1+aYpF2YJfaCHKu+mU=
+github.com/netbirdio/kube-egress-forwarder v0.0.3/go.mod h1:Lyt9k/93DTWaeOiGQWM63WtQNj/9NnMTR/PivDgWXXE=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42 h1:F3zS5fT9xzD1OFLfcdAE+3FfyiwjGukF1hvj0jErgs8=
 github.com/netbirdio/management-integrations/integrations v0.0.0-20260416123949-2355d972be42/go.mod h1:n47r67ZSPgwSmT/Z1o48JjZQW9YJ6m/6Bd/uAXkL3Pg=
 github.com/netbirdio/netbird v0.74.7 h1:my+sDwkFJrp7Q4PEB1/37VW0mo/xCX6DJJtt5PQNlxA=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,7 @@ import (
 const (
 	NetbirdClientImage       = "ghcr.io/netbirdio/netbird:0.74.7@sha256:b63f4c1584118aeebacfdfd841f0351122a53fccac182b4c43be428c2c9a6b73"
 	KubeApiProxyImage        = "ghcr.io/netbirdio/netbird-kubeapi-proxy:v0.0.4@sha256:bffa4f093abc19b4934ae37657bac76fa3b390cbd39aadac987634215eb750f5"
-	KubeEgressForwarderImage = "ghcr.io/netbirdio/kube-egress-forwarder:v0.0.2@sha256:f3b4637122cbda3c1915d49e6f96edff7e3a3accfceb87b821c829056abe8a6f"
+	KubeEgressForwarderImage = "ghcr.io/netbirdio/kube-egress-forwarder:v0.0.3@sha256:8095e8fe03f28c91b9b7bd55617c582143d66fcc5d9bd8264302c97d03c01360"
 )
 
 func BuildVersion() string {


### PR DESCRIPTION
This new version comes with two important fixes. The first is that it resolves failures when the same target is set in many egress resources. The second is that it ensures that the output rules are sorted by name, this way the config map is not updated if nothing has changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/kubernetes-operator/pr/381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787315777&installation_model_id=427504&pr_number=381&repository=netbirdio%2Fkubernetes-operator&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fkubernetes-operator%2Fpull%2F381&signature=b892e51abec537fc5e78a4b27ad397e7e2f649162885c48952e0b7fec760d7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->