### PR TITLE
Mount resolv-conf to all containers in pod that has sidecar injected

### DIFF
--- a/internal/webhook/v1/pod_webhook.go
+++ b/internal/webhook/v1/pod_webhook.go
@@ -108,6 +108,22 @@ func (d *PodNetbirdInjector) Default(ctx context.Context, pod *corev1.Pod) error
 		return err
 	}
 
+	// Add resolv volume to containers.
+	for i, container := range pod.Spec.InitContainers {
+		pod.Spec.InitContainers[i].VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      "resolv-conf",
+			MountPath: "/etc/resolv.conf",
+			SubPath:   "resolv.conf",
+		})
+	}
+	for i, container := range pod.Spec.Containers {
+		pod.Spec.Containers[i].VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      "resolv-conf",
+			MountPath: "/etc/resolv.conf",
+			SubPath:   "resolv.conf",
+		})
+	}
+
 	// Add sidecar container.
 	envVars := []corev1.EnvVar{
 		{

--- a/internal/webhook/v1/pod_webhook_test.go
+++ b/internal/webhook/v1/pod_webhook_test.go
@@ -100,6 +100,9 @@ func TestPodInjectorSidecarProfile(t *testing.T) {
 				require.Len(t, pod.Spec.Containers, 1)
 				require.EqualT(t, "app", pod.Spec.Containers[0].Name)
 			}
+
+			require.EqualT(t, "resolv-conf", pod.Spec.InitContainers[len(pod.Spec.InitContainers)-1].VolumeMounts[0].Name)
+			require.EqualT(t, "resolv-conf", pod.Spec.Containers[len(pod.Spec.Containers)-1].VolumeMounts[0].Name)
 		})
 	}
 }


### PR DESCRIPTION
The changes made making sidecars read only missed adding resolv.conf as a volume mount to all of the containers in the pod. Without this DNS resolution does not work properly.

Fixes #383

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/netbirdio/codesmith/kubernetes-operator/pr/389"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787746744&installation_model_id=427504&pr_number=389&repository=netbirdio%2Fkubernetes-operator&return_to=https%3A%2F%2Fgithub.com%2Fnetbirdio%2Fkubernetes-operator%2Fpull%2F389&signature=b50a1bacad881db0ccda687b0a4140968762de3facee6a2c63a3480f6f30fb5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated pod networking injection to ensure `/etc/resolv.conf` is available in all initialization and application containers.
  * Improved DNS configuration consistency for injected workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->