### PR TITLE
fix: reconcile existing NetworkResource DNS records

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 const ReadyCondition = "Ready"
 
 const (
-	ReconciledReason = "Reconciled"
-	DependencyReason = "Dependency"
+	ReconciledReason  = "Reconciled"
+	DependencyReason  = "Dependency"
+	DNSConflictReason = "DNSConflict"
 )

--- a/internal/controller/networkresource_controller.go
+++ b/internal/controller/networkresource_controller.go
@@ -4,6 +4,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -120,7 +121,11 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	controllerutil.AddFinalizer(netResource, k8sutil.Finalizer("networkresource"))
+	if controllerutil.AddFinalizer(netResource, k8sutil.Finalizer("networkresource")) {
+		if err := sp.Patch(ctx, netResource); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
 	resourceID, err := func() (string, error) {
 		netReq := api.NetworkResourceRequest{
@@ -163,37 +168,32 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	// If zone has changed we need to delete the old records.
 	if netResource.Status.DNSZoneID != "" && netResource.Status.DNSZoneID != zone.Id {
-		err = r.Netbird.DNSZones.DeleteRecord(ctx, netResource.Status.DNSZoneID, netResource.Status.DNSRecordID)
-		if err != nil && !netbird.IsNotFound(err) {
-			return ctrl.Result{}, err
+		if netResource.Status.DNSRecordID != "" {
+			err = r.Netbird.DNSZones.DeleteRecord(ctx, netResource.Status.DNSZoneID, netResource.Status.DNSRecordID)
+			if err != nil && !netbird.IsNotFound(err) {
+				return ctrl.Result{}, err
+			}
 		}
 		netResource.Status.DNSZoneID = ""
 		netResource.Status.DNSRecordID = ""
 	}
 
-	recordID, err := func() (string, error) {
-		dnsReq := api.DNSRecordRequest{
-			Content: svc.Spec.ClusterIP,
-			Name:    strings.Join([]string{svc.Name, svc.Namespace, zone.Name}, "."),
-			Ttl:     int(5 * time.Minute / time.Second),
-			Type:    api.DNSRecordTypeA,
-		}
-		if netResource.Status.DNSZoneID != "" && netResource.Status.DNSRecordID != "" {
-			recordResp, err := r.Netbird.DNSZones.UpdateRecord(ctx, netResource.Status.DNSZoneID, netResource.Status.DNSRecordID, dnsReq)
-			if err != nil && !netbird.IsNotFound(err) {
-				return "", err
-			}
-			if err == nil {
-				return recordResp.Id, nil
-			}
-		}
-		recordResp, err := r.Netbird.DNSZones.CreateRecord(ctx, zone.Id, dnsReq)
-		if err != nil {
-			return "", err
-		}
-		return recordResp.Id, nil
-	}()
+	dnsReq := api.DNSRecordRequest{
+		Content: svc.Spec.ClusterIP,
+		Name:    strings.Join([]string{svc.Name, svc.Namespace, zone.Name}, "."),
+		Ttl:     int(5 * time.Minute / time.Second),
+		Type:    api.DNSRecordTypeA,
+	}
+	recordID, err := r.ensureDNSRecord(ctx, netResource, zone.Id, dnsReq)
 	if err != nil {
+		var conflictErr *dnsRecordConflictError
+		if errors.As(err, &conflictErr) {
+			conditions.MarkFalse(netResource, nbv1alpha1.ReadyCondition, nbv1alpha1.DNSConflictReason, "%s", conflictErr.Error())
+			if patchErr := sp.Patch(ctx, netResource, patch.WithStatusObservedGeneration{}); patchErr != nil {
+				return ctrl.Result{}, patchErr
+			}
+			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+		}
 		return ctrl.Result{}, err
 	}
 	netResource.Status.DNSZoneID = zone.Id
@@ -205,6 +205,97 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+type dnsRecordConflictError struct {
+	message string
+}
+
+func (e *dnsRecordConflictError) Error() string {
+	return e.message
+}
+
+func selectDNSRecord(records []api.DNSRecord, request api.DNSRecordRequest) (*api.DNSRecord, error) {
+	var exact *api.DNSRecord
+	for i := range records {
+		record := &records[i]
+		if record.Name != request.Name {
+			continue
+		}
+		if record.Type != request.Type || record.Content != request.Content {
+			return nil, &dnsRecordConflictError{message: fmt.Sprintf("DNS name %q already exists with different type or content", request.Name)}
+		}
+		if exact != nil {
+			return nil, &dnsRecordConflictError{message: fmt.Sprintf("DNS name %q has multiple matching records", request.Name)}
+		}
+		exact = record
+	}
+	return exact, nil
+}
+
+func (r *NetworkResourceReconciler) adoptDNSRecord(ctx context.Context, netResource *nbv1alpha1.NetworkResource, zoneID string, request api.DNSRecordRequest) (*api.DNSRecord, error) {
+	records, err := r.Netbird.DNSZones.ListRecords(ctx, zoneID)
+	if err != nil {
+		return nil, err
+	}
+	record, err := selectDNSRecord(records, request)
+	if err != nil || record == nil {
+		return record, err
+	}
+
+	var resources nbv1alpha1.NetworkResourceList
+	if err := r.List(ctx, &resources); err != nil {
+		return nil, err
+	}
+	for i := range resources.Items {
+		owner := &resources.Items[i]
+		if owner.Namespace == netResource.Namespace && owner.Name == netResource.Name {
+			continue
+		}
+		if owner.Status.DNSZoneID == zoneID && owner.Status.DNSRecordID == record.Id {
+			return nil, &dnsRecordConflictError{message: fmt.Sprintf("DNS record %q is already owned by NetworkResource %s/%s", request.Name, owner.Namespace, owner.Name)}
+		}
+	}
+	return record, nil
+}
+
+func (r *NetworkResourceReconciler) ensureDNSRecord(ctx context.Context, netResource *nbv1alpha1.NetworkResource, zoneID string, request api.DNSRecordRequest) (string, error) {
+	if netResource.Status.DNSZoneID != "" && netResource.Status.DNSRecordID != "" {
+		record, err := r.Netbird.DNSZones.UpdateRecord(ctx, netResource.Status.DNSZoneID, netResource.Status.DNSRecordID, request)
+		if err == nil {
+			return record.Id, nil
+		}
+		if !netbird.IsNotFound(err) {
+			return "", err
+		}
+	}
+
+	record, err := r.adoptDNSRecord(ctx, netResource, zoneID, request)
+	if err != nil {
+		return "", err
+	}
+	if record != nil {
+		return record.Id, nil
+	}
+
+	record, createErr := r.Netbird.DNSZones.CreateRecord(ctx, zoneID, request)
+	if createErr == nil {
+		return record.Id, nil
+	}
+
+	// The management API may have committed the record before the client saw
+	// an error, or another reconciliation may have won the create race.
+	record, adoptErr := r.adoptDNSRecord(ctx, netResource, zoneID, request)
+	if adoptErr == nil && record != nil {
+		return record.Id, nil
+	}
+	if adoptErr != nil {
+		var conflictErr *dnsRecordConflictError
+		if errors.As(adoptErr, &conflictErr) {
+			return "", conflictErr
+		}
+	}
+	return "", createErr
 }
 
 func (r *NetworkResourceReconciler) reconcileDelete(ctx context.Context, sp *patch.SerialPatcher, netResource *nbv1alpha1.NetworkResource) (ctrl.Result, error) {

--- a/internal/controller/networkresource_dns_test.go
+++ b/internal/controller/networkresource_dns_test.go
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: BSD-3-Clause
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	netbird "github.com/netbirdio/netbird/shared/management/client/rest"
+	"github.com/netbirdio/netbird/shared/management/http/api"
+
+	nbv1alpha1 "github.com/netbirdio/kubernetes-operator/api/v1alpha1"
+	"github.com/netbirdio/kubernetes-operator/internal/k8sutil"
+	"github.com/netbirdio/kubernetes-operator/internal/netbirdmock"
+)
+
+func TestSelectDNSRecord(t *testing.T) {
+	t.Parallel()
+
+	request := api.DNSRecordRequest{
+		Name:    "service.namespace.cluster.local",
+		Type:    api.DNSRecordTypeA,
+		Content: "10.43.0.10",
+		Ttl:     300,
+	}
+	exact := api.DNSRecord{Id: "exact", Name: request.Name, Type: request.Type, Content: request.Content, Ttl: 60}
+
+	tests := map[string]struct {
+		records []api.DNSRecord
+		wantID  string
+		wantErr bool
+	}{
+		"missing":             {},
+		"exact":               {records: []api.DNSRecord{exact}, wantID: exact.Id},
+		"other name ignored":  {records: []api.DNSRecord{{Id: "other", Name: "other.cluster.local", Type: request.Type, Content: request.Content}}},
+		"different content":   {records: []api.DNSRecord{{Id: "conflict", Name: request.Name, Type: request.Type, Content: "10.43.0.11"}}, wantErr: true},
+		"different type":      {records: []api.DNSRecord{{Id: "conflict", Name: request.Name, Type: api.DNSRecordTypeCNAME, Content: request.Content}}, wantErr: true},
+		"multiple exact":      {records: []api.DNSRecord{exact, {Id: "duplicate", Name: request.Name, Type: request.Type, Content: request.Content}}, wantErr: true},
+		"exact plus conflict": {records: []api.DNSRecord{exact, {Id: "conflict", Name: request.Name, Type: request.Type, Content: "10.43.0.11"}}, wantErr: true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			record, err := selectDNSRecord(tt.records, request)
+			if tt.wantErr {
+				require.Error(t, err)
+				var conflictErr *dnsRecordConflictError
+				require.ErrorAs(t, err, &conflictErr)
+				return
+			}
+			require.NoError(t, err)
+			if tt.wantID == "" {
+				require.Nil(t, record)
+				return
+			}
+			require.Equal(t, tt.wantID, record.Id)
+		})
+	}
+}
+
+func TestEnsureDNSRecordAdoptsRecordAfterCreateConflict(t *testing.T) {
+	t.Parallel()
+
+	request := api.DNSRecordRequest{
+		Name:    "service.namespace.cluster.local",
+		Type:    api.DNSRecordTypeA,
+		Content: "10.43.0.10",
+		Ttl:     300,
+	}
+	var persisted atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/dns/zones/zone-id/records":
+			records := []api.DNSRecord{}
+			if persisted.Load() {
+				records = append(records, api.DNSRecord{Id: "adopted", Name: request.Name, Type: request.Type, Content: request.Content, Ttl: request.Ttl})
+			}
+			if err := json.NewEncoder(w).Encode(records); err != nil {
+				t.Errorf("encode DNS records: %v", err)
+			}
+		case r.Method == http.MethodPost && r.URL.Path == "/api/dns/zones/zone-id/records":
+			persisted.Store(true)
+			w.WriteHeader(http.StatusConflict)
+			if err := json.NewEncoder(w).Encode(map[string]string{"message": "identical record already exists"}); err != nil {
+				t.Errorf("encode conflict response: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, nbv1alpha1.AddToScheme(scheme))
+	netResource := &nbv1alpha1.NetworkResource{ObjectMeta: metav1.ObjectMeta{Name: "resource", Namespace: "namespace"}}
+	r := &NetworkResourceReconciler{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(netResource).Build(),
+		Netbird: netbird.New(server.URL, "token"),
+	}
+
+	recordID, err := r.ensureDNSRecord(context.Background(), netResource, "zone-id", request)
+	require.NoError(t, err)
+	require.Equal(t, "adopted", recordID)
+}
+
+func TestAdoptDNSRecordRejectsAnotherNetworkResourceOwner(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	nbClient := netbirdmock.Client()
+	zone, err := nbClient.DNSZones.CreateZone(ctx, api.ZoneRequest{Name: "cluster.local", Domain: "cluster.local"})
+	require.NoError(t, err)
+	request := api.DNSRecordRequest{Name: "service.namespace.cluster.local", Type: api.DNSRecordTypeA, Content: "10.43.0.10", Ttl: 300}
+	record, err := nbClient.DNSZones.CreateRecord(ctx, zone.Id, request)
+	require.NoError(t, err)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, nbv1alpha1.AddToScheme(scheme))
+	current := &nbv1alpha1.NetworkResource{ObjectMeta: metav1.ObjectMeta{Name: "current", Namespace: "namespace"}}
+	owner := &nbv1alpha1.NetworkResource{
+		ObjectMeta: metav1.ObjectMeta{Name: "owner", Namespace: "namespace"},
+		Status: nbv1alpha1.NetworkResourceStatus{
+			DNSZoneID:   zone.Id,
+			DNSRecordID: record.Id,
+		},
+	}
+	r := &NetworkResourceReconciler{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(current, owner).Build(),
+		Netbird: nbClient,
+	}
+
+	_, err = r.adoptDNSRecord(ctx, current, zone.Id, request)
+	require.Error(t, err)
+	var conflictErr *dnsRecordConflictError
+	require.ErrorAs(t, err, &conflictErr)
+}
+
+func TestAdoptDNSRecordScopesLookupToZone(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	request := api.DNSRecordRequest{Name: "service.namespace.target.local", Type: api.DNSRecordTypeA, Content: "10.43.0.10", Ttl: 300}
+	var otherZoneListed atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/dns/zones/target-zone/records":
+			if err := json.NewEncoder(w).Encode([]api.DNSRecord{}); err != nil {
+				t.Errorf("encode target-zone records: %v", err)
+			}
+		case "/api/dns/zones/other-zone/records":
+			otherZoneListed.Store(true)
+			if err := json.NewEncoder(w).Encode([]api.DNSRecord{{Id: "conflict", Name: request.Name, Type: request.Type, Content: "10.43.0.11"}}); err != nil {
+				t.Errorf("encode other-zone records: %v", err)
+			}
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, nbv1alpha1.AddToScheme(scheme))
+	current := &nbv1alpha1.NetworkResource{ObjectMeta: metav1.ObjectMeta{Name: "current", Namespace: "namespace"}}
+	r := &NetworkResourceReconciler{
+		Client:  fake.NewClientBuilder().WithScheme(scheme).WithObjects(current).Build(),
+		Netbird: netbird.New(server.URL, "token"),
+	}
+
+	record, err := r.adoptDNSRecord(ctx, current, "target-zone", request)
+	require.NoError(t, err)
+	require.Nil(t, record)
+	require.False(t, otherZoneListed.Load())
+}
+
+type failingPatchClient struct {
+	client.Client
+	err error
+}
+
+func (c *failingPatchClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
+	return c.err
+}
+
+func TestNetworkResourcePersistsFinalizerBeforeExternalMutation(t *testing.T) {
+	t.Parallel()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, nbv1alpha1.AddToScheme(scheme))
+
+	nn := client.ObjectKey{Name: "resource", Namespace: "namespace"}
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: "service", Namespace: nn.Namespace},
+		Spec: corev1.ServiceSpec{
+			Type:      corev1.ServiceTypeClusterIP,
+			ClusterIP: "10.43.0.10",
+		},
+	}
+	router := &nbv1alpha1.NetworkRouter{
+		ObjectMeta: metav1.ObjectMeta{Name: "router", Namespace: nn.Namespace},
+		Status: nbv1alpha1.NetworkRouterStatus{
+			NetworkID:     "network-id",
+			RoutingPeerID: "routing-peer-id",
+		},
+	}
+	netResource := &nbv1alpha1.NetworkResource{
+		ObjectMeta: metav1.ObjectMeta{Name: nn.Name, Namespace: nn.Namespace},
+		Spec: nbv1alpha1.NetworkResourceSpec{
+			ServiceRef:       corev1.LocalObjectReference{Name: service.Name},
+			NetworkRouterRef: nbv1alpha1.CrossNamespaceReference{Name: router.Name, Namespace: router.Namespace},
+		},
+	}
+	baseClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(service, router, netResource).Build()
+	patchErr := errors.New("persist finalizer")
+	r := &NetworkResourceReconciler{Client: &failingPatchClient{Client: baseClient, err: patchErr}}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: nn})
+	require.ErrorIs(t, err, patchErr)
+
+	stored := &nbv1alpha1.NetworkResource{}
+	require.NoError(t, baseClient.Get(context.Background(), nn, stored))
+	require.NotContains(t, stored.Finalizers, k8sutil.Finalizer("networkresource"))
+}


### PR DESCRIPTION
## Summary
- persist the NetworkResource finalizer before creating external resources
- adopt an exact, unowned DNS record when status persistence was interrupted
- re-list after failed creates to recover committed responses and create races
- expose ambiguous or non-identical records through a `DNSConflict` condition
- avoid deleting an empty DNS record ID during zone changes

## Why
If the management API commits a DNS record but the final Kubernetes status patch fails, the next reconcile currently retries `CreateRecord` forever with `identical record already exists`. External cleanup cannot safely infer ownership from object age or DNS name. The controller has enough state to recover this itself.

## Verification
- focused DNS reconciliation tests under `go test -race`
- complete `go test ./...` with Kubernetes 1.36.2 envtest
- tests cover finalizer ordering, interrupted create adoption, conflicting ownership, ambiguous records, and zone-scoped lookup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DNS record reconciliation by updating existing records when appropriate and adopting matching records.
  * Detects conflicting DNS names or ownership and marks the network resource as not ready instead of applying an incorrect record.
  * Automatically retries DNS record adoption after creation conflicts.
  * Ensures resource state is saved reliably before external DNS changes are made.

* **Tests**
  * Expanded coverage for DNS conflicts, record adoption, ownership validation, zone-scoped lookups, and reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->