### PR TITLE
[helm] Add managementURL to values.yaml

### DIFF
--- a/charts/netbird-operator/values.yaml
+++ b/charts/netbird-operator/values.yaml
@@ -153,6 +153,9 @@ netbirdAPI:
     name: "netbird-mgmt-api-key"
     key: "NB_API_KEY"
 
+# NetBird management URL. Defaults to NetBird Cloud
+# managementURL: "https://api.netbird.io"
+
 #routingClientImage: "netbirdio/netbird:latest"
 
 gatewayAPI:


### PR DESCRIPTION
Add managementURL to values.yaml to document its purpose and default value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring the optional NetBird management URL.
  * Clarified that NetBird Cloud is used by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->