### PR TITLE
Name network resources after the service instead of the CR UID

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -306,8 +306,9 @@ func main() {
 			os.Exit(1)
 		}
 		if err := (&controller.NetworkResourceReconciler{
-			Client:  mgr.GetClient(),
-			Netbird: nbClient,
+			Client:      mgr.GetClient(),
+			Netbird:     nbClient,
+			ClusterName: clusterName,
 		}).SetupWithManager(mgr); err != nil {
 			setupLog.Error(err, "Failed to create controller", "controller", "NetworkResource")
 			os.Exit(1)

--- a/internal/controller/networkresource_controller.go
+++ b/internal/controller/networkresource_controller.go
@@ -34,6 +34,8 @@ type NetworkResourceReconciler struct {
 	client.Client
 
 	Netbird *netbird.Client
+	// ClusterName prefixes NetBird resource names, which are unique per account.
+	ClusterName string
 }
 
 // +kubebuilder:rbac:groups=netbird.io,resources=networkresources,verbs=get;list;watch;create;update;patch;delete
@@ -124,7 +126,7 @@ func (r *NetworkResourceReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	resourceID, err := func() (string, error) {
 		netReq := api.NetworkResourceRequest{
-			Name:        string(netResource.UID),
+			Name:        fmt.Sprintf("%s-%s-%s", r.ClusterName, svc.Namespace, svc.Name),
 			Description: new(svc.Name + "/" + svc.Namespace),
 			Address:     svc.Spec.ClusterIP,
 			Enabled:     true,

--- a/internal/controller/networkrouter_controller.go
+++ b/internal/controller/networkrouter_controller.go
@@ -385,10 +385,14 @@ func (r *NetworkRouterReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 			if err != nil {
 				return ctrl.Result{}, err
 			}
-			err = json.Unmarshal(mergedJSON, &podTemplateSpecAC)
+			// Into a fresh value: decoding into the populated struct reuses its
+			// env slice elements, leaving entries with both value and valueFrom.
+			merged := corev1ac.PodTemplateSpec()
+			err = json.Unmarshal(mergedJSON, merged)
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+			podTemplateSpecAC = merged
 		}
 	}
 	maps.Copy(workloadLabels, selectorLabels)


### PR DESCRIPTION
Resources currently get named with the CR UID, so in the dashboard and netbird networks list you see 3998c371-9036-4421-98a3-bfdfd650f9dd and have no idea what it is. This uses <cluster-name>-<namespace>-<service> instead. Still unique per account since the cluster name is in there. Existing resources just get renamed on the next reconcile, nothing else changes. If you don't want the default to change I can make it a spec.name field.

Also fixes workloadOverride.podTemplate when it adds env vars. The merged template is unmarshalled back into the existing apply configuration, which reuses the env slice, so the operator's own vars end up with both value and valueFrom and the Deployment is rejected:

spec.template.spec.containers[0].env[0].valueFrom: Invalid value: "": may not be specified when `value` is not empty

Decoding into a fresh value fixes it. Can split this out into its own PR if you'd rather.

Based on v0.8.0, make test-unit passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Network resources now use consistent names based on the cluster, namespace, and service, making them easier to identify and manage.
  - Workload pod template overrides now merge environment variable settings correctly, preventing conflicting configuration values.

- **Bug Fixes**
  - Fixed an issue where overridden environment variables could retain both direct values and value references after configuration merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->